### PR TITLE
Enable loading model from hub that has already been converted 

### DIFF
--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -95,7 +95,7 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
             self.eos_token_id = self.model.run_method("get_eos_id")[0]
         if "get_vocab_size" in metadata:
             self.vocab_size = self.model.run_method("get_vocab_size")[0]
-            
+
     def forward(
         self,
         input_ids: torch.Tensor,

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -38,6 +38,9 @@ from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
 from ..utils.file_utils import _find_files_matching_pattern
 
 
+_FILE_PATTERN = r"^.*\.pte$"
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -429,7 +432,7 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
 
             pte_files = _find_files_matching_pattern(
                 model_dir,
-                pattern=r"(.*).pte$",
+                pattern=_FILE_PATTERN,
                 subfolder=subfolder,
                 token=token,
                 revision=revision,

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -208,7 +208,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
         force_download: bool = False,
         local_files_only: bool = False,
-        use_auth_token: Optional[Union[bool, str]] = None,
         token: Optional[Union[bool, str]] = None,
     ) -> "ExecuTorchModelForCausalLM":
         """
@@ -231,8 +230,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
                 cached versions if they exist.
             local_files_only (`Optional[bool]`, defaults to `False`):
                 Whether or not to only look at local files (i.e., do not try to download the model).
-            use_auth_token (`Optional[Union[bool,str]]`, defaults to `None`):
-                Deprecated. Please use the `token` argument instead.
             token (`Optional[Union[bool,str]]`, defaults to `None`):
                 The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
                 when running `huggingface-cli login` (stored in `huggingface_hub.constants.HF_TOKEN_PATH`).
@@ -270,7 +267,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
         revision: Optional[str] = None,
         force_download: bool = False,
         local_files_only: bool = False,
-        use_auth_token: Optional[Union[bool, str]] = None,
         token: Optional[Union[bool, str]] = None,
         **kwargs,
     ):
@@ -302,8 +298,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
                 cached versions if they exist.
             local_files_only (`Optional[bool]`, defaults to `False`):
                 Whether or not to only look at local files (i.e., do not try to download the model).
-            use_auth_token (`Optional[Union[bool,str]]`, defaults to `None`):
-                Deprecated. Please use the `token` argument instead.
             token (`Optional[Union[bool,str]]`, defaults to `None`):
                 The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
                 when running `huggingface-cli login` (stored in `huggingface_hub.constants.HF_TOKEN_PATH`).
@@ -314,14 +308,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
             `ExecuTorchModelForCausalLM`: The loaded and exported ExecuTorch model.
 
         """
-        if use_auth_token is not None:
-            warnings.warn(
-                "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead.",
-                FutureWarning,
-            )
-            if token is not None:
-                raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
-            token = use_auth_token
 
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
@@ -345,7 +331,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
         return cls._from_pretrained(
             model_dir_path=save_dir_path,
             config=config,
-            use_auth_token=use_auth_token,
             subfolder=subfolder,
             revision=revision,
             cache_dir=cache_dir,

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -127,7 +127,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
         file_name: Optional[str] = None,
         **kwargs,
     ) -> "ExecuTorchModelForCausalLM":
-
         model_path = Path(model_id)
         default_file_name = file_name or "model.pte"
 

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -406,15 +406,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
         config: Optional[PretrainedConfig] = None,
         **kwargs,
     ):
-        use_auth_token = kwargs.pop("use_auth_token", None)
-        if use_auth_token is not None:
-            logger.warning(
-                "The `use_auth_token` argument is deprecated and will be removed soon. Please use the `token` argument instead."
-            )
-            if token is not None:
-                raise ValueError("You cannot use both `use_auth_token` and `token` arguments at the same time.")
-            token = use_auth_token
-
         if isinstance(model_id, Path):
             model_id = model_id.as_posix()
 
@@ -447,7 +438,7 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
                     _export = True
                 else:
                     logger.warning(
-                        f"No ExecuTorch files were found for {model_id}, setting `export=True` to convert the model to the OpenVINO IR. "
+                        f"No ExecuTorch files were found for {model_id}, setting `export=True` to convert the model to the ExecuTorch IR. "
                         # "Don't forget to save the resulting model with `.save_pretrained()`"
                     )
         except Exception as exception:
@@ -455,7 +446,7 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
                 f"Could not infer whether the model was already converted or not to the ExecuTorch IR, keeping `export={export}`.\n{exception}"
             )
 
-        from_pretrained_method = cls._export if export else cls._from_pretrained
+        from_pretrained_method = cls._export if _export else cls._from_pretrained
 
         return from_pretrained_method(
             model_id=model_id,

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -73,7 +73,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
 
     def __init__(self, model: "ExecuTorchModule", config: "PretrainedConfig"):
         super().__init__(model, config)
-        # self.model = model
         metadata = self.model.method_names()
         logging.info(f"Load all static methods: {metadata}")
         if "use_kv_cache" in metadata:
@@ -120,7 +119,6 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
         force_download: bool = False,
         local_files_only: bool = False,
         **kwargs,
-        # model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
     ) -> "ExecuTorchModelForCausalLM":
         """
         Load a pre-trained ExecuTorch model from a local directory or hosted on the HF hub.

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ except Exception as error:
     assert False, "Error: Could not open '%s' due %s\n" % (filepath, error)
 
 INSTALL_REQUIRE = [
-    # "optimum~=1.24",
-    "optimum@git+https://github.com/huggingface/optimum.git@infer-export",
+    "optimum~=1.24",
     "executorch>=0.4.0",
     "transformers>=4.46",
 ]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except Exception as error:
 
 INSTALL_REQUIRE = [
     # "optimum~=1.24",
-    "optimum@git+https://github.com/huggingface/optimum.git",
+    "optimum@git+https://github.com/huggingface/optimum.git@infer-export",
     "executorch>=0.4.0",
     "transformers>=4.46",
 ]

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -46,7 +46,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
-    def test_load_model_from_local_path(self):
+    def test_load_cached_model_from_local_path(self):
         model_id = "optimum-internal-testing/tiny-random-llama"
         recipe = "xnnpack"
 

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -53,6 +53,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                 model_name_or_path=model_id,
                 recipe=recipe,
                 output_dir=tempdir,
+                task="text-generation",
             )
             self.assertTrue(os.path.exists(f"{tempdir}/model.pte"))
 

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -31,11 +31,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     def test_load_model_from_hub(self):
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_name_or_path="NousResearch/Llama-3.2-1B",
-            export=True,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained("NousResearch/Llama-3.2-1B", export=True, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -59,9 +55,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             self.assertTrue(os.path.exists(f"{tempdir}/model.pte"))
 
             # Load the exported model from a local dir
-            model = ExecuTorchModelForCausalLM.from_pretrained(
-                model_name_or_path=tempdir,
-                export=False,
-            )
+            model = ExecuTorchModelForCausalLM.from_pretrained(tempdir, export=False)
             self.assertIsInstance(model, ExecuTorchModelForCausalLM)
             self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -42,7 +42,11 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def test_load_et_model_from_hub(self):
         model_id = "optimum-internal-testing/tiny-random-llama"
 
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, revision="executorch", recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, revision="executorch")
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, revision="executorch-subfolder")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -25,7 +25,7 @@ from huggingface_hub import HfApi
 from optimum.executorch import ExecuTorchModelForCausalLM
 from optimum.executorch.modeling import _FILE_PATTERN
 from optimum.exporters.executorch import main_export
-from optimum.utils.file_utils import _find_files_matching_pattern
+from optimum.utils.file_utils import find_files_matching_pattern
 
 
 class ExecuTorchModelIntegrationTest(unittest.TestCase):
@@ -70,7 +70,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # hub model
         for revision in ("main", "executorch"):
-            pte_files = _find_files_matching_pattern(model_id, pattern=_FILE_PATTERN, revision=revision)
+            pte_files = find_files_matching_pattern(model_id, pattern=_FILE_PATTERN, revision=revision)
             self.assertTrue(len(pte_files) == 0 if revision == "main" else len(pte_files) > 0)
 
         # local model
@@ -79,5 +79,5 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             for revision in ("main", "executorch"):
                 local_dir = Path(tmpdirname) / revision
                 api.snapshot_download(repo_id=model_id, local_dir=local_dir, revision=revision)
-                pte_files = _find_files_matching_pattern(local_dir, pattern=_FILE_PATTERN, revision=revision)
+                pte_files = find_files_matching_pattern(local_dir, pattern=_FILE_PATTERN, revision=revision)
                 self.assertTrue(len(pte_files) == 0 if revision == "main" else len(pte_files) > 0)

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -42,9 +42,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def test_load_et_model_from_hub(self):
         model_id = "optimum-internal-testing/tiny-random-llama"
 
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_id, export=False, revision="executorch", recipe="xnnpack"
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, revision="executorch", recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -32,7 +32,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def test_load_model_from_hub(self):
+    def test_load_cached_model_from_hub(self):
         model_id = "optimum-internal-testing/tiny-random-llama"
 
         model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -17,38 +17,40 @@ import os
 import tempfile
 import unittest
 
-import pytest
 from executorch.extension.pybindings.portable_lib import ExecuTorchModule
-from transformers.testing_utils import slow
 
 from optimum.executorch import ExecuTorchModelForCausalLM
+from optimum.exporters.executorch import main_export
 
 
 class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @slow
-    @pytest.mark.run_slow
     def test_load_model_from_hub(self):
-        model = ExecuTorchModelForCausalLM.from_pretrained("NousResearch/Llama-3.2-1B", export=True, recipe="xnnpack")
+        model_id = "optimum-internal-testing/tiny-random-llama"
+
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
-    @slow
-    @pytest.mark.run_slow
-    def test_load_model_from_local_path(self):
-        from optimum.exporters.executorch import main_export
+    def test_load_et_model_from_hub(self):
+        model_id = "optimum-internal-testing/tiny-random-llama"
 
-        model_id = "NousResearch/Llama-3.2-1B"
-        task = "text-generation"
+        model = ExecuTorchModelForCausalLM.from_pretrained(
+            model_id, export=False, revision="executorch", recipe="xnnpack"
+        )
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+
+    def test_load_model_from_local_path(self):
+        model_id = "optimum-internal-testing/tiny-random-llama"
         recipe = "xnnpack"
 
         with tempfile.TemporaryDirectory() as tempdir:
             # Export to a local dir
             main_export(
                 model_name_or_path=model_id,
-                task=task,
                 recipe=recipe,
                 output_dir=tempdir,
             )

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -81,7 +81,5 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             for revision in ("main", "executorch"):
                 local_dir = Path(tmpdirname) / revision
                 api.snapshot_download(repo_id=model_id, local_dir=local_dir, revision=revision)
-                pte_files = _find_files_matching_pattern(
-                    local_dir, pattern=pattern, revision=revision, subfolder=revision
-                )
+                pte_files = _find_files_matching_pattern(local_dir, pattern=pattern, revision=revision)
                 self.assertTrue(len(pte_files) == 0 if revision == "main" else len(pte_files) > 0)

--- a/tests/models/test_modeling.py
+++ b/tests/models/test_modeling.py
@@ -23,6 +23,7 @@ from executorch.extension.pybindings.portable_lib import ExecuTorchModule
 from huggingface_hub import HfApi
 
 from optimum.executorch import ExecuTorchModelForCausalLM
+from optimum.executorch.modeling import _FILE_PATTERN
 from optimum.exporters.executorch import main_export
 from optimum.utils.file_utils import _find_files_matching_pattern
 
@@ -68,11 +69,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     def test_find_files_matching_pattern(self):
         model_id = "optimum-internal-testing/tiny-random-llama"
-        pattern = r"(.*).pte$"
 
         # hub model
         for revision in ("main", "executorch"):
-            pte_files = _find_files_matching_pattern(model_id, pattern=pattern, revision=revision)
+            pte_files = _find_files_matching_pattern(model_id, pattern=_FILE_PATTERN, revision=revision)
             self.assertTrue(len(pte_files) == 0 if revision == "main" else len(pte_files) > 0)
 
         # local model
@@ -81,5 +81,5 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             for revision in ("main", "executorch"):
                 local_dir = Path(tmpdirname) / revision
                 api.snapshot_download(repo_id=model_id, local_dir=local_dir, revision=revision)
-                pte_files = _find_files_matching_pattern(local_dir, pattern=pattern, revision=revision)
+                pte_files = _find_files_matching_pattern(local_dir, pattern=_FILE_PATTERN, revision=revision)
                 self.assertTrue(len(pte_files) == 0 if revision == "main" else len(pte_files) > 0)

--- a/tests/models/test_modeling_gemma.py
+++ b/tests/models/test_modeling_gemma.py
@@ -33,11 +33,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use google/gemma-2b once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "google/gemma-2b"
         model_id = "weqweasdas/RM-Gemma-2B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_name_or_path=model_id,
-            export=True,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_gemma.py
+++ b/tests/models/test_modeling_gemma.py
@@ -33,7 +33,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use google/gemma-2b once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "google/gemma-2b"
         model_id = "weqweasdas/RM-Gemma-2B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_gemma2.py
+++ b/tests/models/test_modeling_gemma2.py
@@ -33,11 +33,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use google/gemma-2-2b once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "google/gemma-2-2b"
         model_id = "unsloth/gemma-2-2b-it"
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_name_or_path=model_id,
-            export=True,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_gemma2.py
+++ b/tests/models/test_modeling_gemma2.py
@@ -33,7 +33,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use google/gemma-2-2b once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "google/gemma-2-2b"
         model_id = "unsloth/gemma-2-2b-it"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -33,7 +33,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use meta-llama/Llama-3.2-1B once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "lama/Llama-3.2-1B"
         model_id = "NousResearch/Llama-3.2-1B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -53,7 +53,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use meta-llama/Llama-3.2-3B once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "lama/Llama-3.2-3B"
         model_id = "NousResearch/Hermes-3-Llama-3.2-3B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
 
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -33,11 +33,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use meta-llama/Llama-3.2-1B once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "lama/Llama-3.2-1B"
         model_id = "NousResearch/Llama-3.2-1B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_name_or_path=model_id,
-            export=True,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -57,11 +53,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         # TODO: Switch to use meta-llama/Llama-3.2-3B once https://github.com/huggingface/optimum/issues/2127 is fixed
         # model_id = "lama/Llama-3.2-3B"
         model_id = "NousResearch/Hermes-3-Llama-3.2-3B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_name_or_path=model_id,
-            export=True,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
+
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_olmo.py
+++ b/tests/models/test_modeling_olmo.py
@@ -31,11 +31,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @pytest.mark.run_slow
     def test_olmo_text_generation_with_xnnpack(self):
         model_id = "allenai/OLMo-1B-hf"
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_name_or_path=model_id,
-            export=True,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_olmo.py
+++ b/tests/models/test_modeling_olmo.py
@@ -31,7 +31,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @pytest.mark.run_slow
     def test_olmo_text_generation_with_xnnpack(self):
         model_id = "allenai/OLMo-1B-hf"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_qwen2.py
+++ b/tests/models/test_modeling_qwen2.py
@@ -31,11 +31,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @pytest.mark.run_slow
     def test_qwen2_5_text_generation_with_xnnpack(self):
         model_id = "Qwen/Qwen2.5-0.5B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_name_or_path=model_id,
-            export=True,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 

--- a/tests/models/test_modeling_qwen2.py
+++ b/tests/models/test_modeling_qwen2.py
@@ -31,7 +31,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @pytest.mark.run_slow
     def test_qwen2_5_text_generation_with_xnnpack(self):
         model_id = "Qwen/Qwen2.5-0.5B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, export=True, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 


### PR DESCRIPTION
* Enable loading model from the hub that have already been converted to executorch like [this model](https://huggingface.co/optimum-internal-testing/tiny-random-llama/tree/executorch)

* Infer whether the model should be exported or not by checking whether a `.pte` file is present when loading the model

```python
from optimum.executorch import ExecuTorchModelForCausalLM

model_id = "optimum-internal-testing/tiny-random-llama"
model = ExecuTorchModelForCausalLM.from_pretrained(model_id, revision="executorch")
``` 