### PR TITLE
Update CI runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build_documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build_documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
ubuntu 20.04 actions runner image is deprecated https://github.com/actions/runner-images/issues/11101