### PR TITLE
Version bump and fixes

### DIFF
--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -25,6 +25,7 @@ jobs:
           - gemma2
           - llama
           - olmo
+          - phi4
           - qwen2
           - roberta
           - t5

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ We currently support a wide range of popular transformer models, including encod
 - [Llama](https://huggingface.co/meta-llama/Llama-3.2-1B): `Llama-3.2-1B` and its variants
 - [Qwen2](https://huggingface.co/Qwen/Qwen2.5-0.5B): `Qwen2.5-0.5B` and its variants
 - [Olmo](https://huggingface.co/allenai/OLMo-1B-hf): `OLMo-1B-hf` and its variants
+- [Phi4](https://huggingface.co/microsoft/Phi-4-mini-instruct): `Phi-4-mini-instruct` and its variants
 - [Roberta](https://huggingface.co/FacebookAI/xlm-roberta-base): FacebookAI's `xlm-roberta-base` and its variants
 - [Smollm](https://huggingface.co/HuggingFaceTB/SmolLM2-135M): 🤗 `SmolLM2-135M` and its variants
 - [T5](https://huggingface.co/google-t5/t5-small): Google's `T5` and its variants

--- a/optimum/exporters/executorch/__main__.py
+++ b/optimum/exporters/executorch/__main__.py
@@ -20,6 +20,7 @@ import warnings
 from pathlib import Path
 
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
+from transformers import PretrainedConfig
 from transformers.utils import is_torch_available
 
 from optimum.utils.import_utils import is_transformers_version
@@ -40,6 +41,7 @@ def main_export(
     task: str,
     recipe: str,
     output_dir: Union[str, Path],
+    config: Optional[PretrainedConfig] = None,
     cache_dir: str = HUGGINGFACE_HUB_CACHE,
     trust_remote_code: bool = False,
     pad_token_id: Optional[int] = None,
@@ -63,6 +65,8 @@ def main_export(
             The recipe to use to do the export, e.g. "xnnpack".
         output_dir (`Union[str, Path]`):
             Path indicating the directory where to store the generated ExecuTorch model.
+        config (`Optional[PretrainedConfig]`, defaults to `None`):
+            The model configuration to use to load the model.
         cache_dir (`Optional[str]`, defaults to `None`):
             Path indicating where to store cache. The default Hugging Face cache path will be used by default.
         trust_remote_code (`bool`, defaults to `False`):
@@ -124,6 +128,7 @@ def main_export(
     kwargs["subfolder"] = subfolder
     kwargs["revision"] = revision
     kwargs["force_download"] = force_download
+    kwargs["config"] = config
 
     model = task_func(model_name_or_path, **kwargs)
 

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -197,7 +197,7 @@ class Seq2SeqLMExportableModule(torch.nn.Module):
         self.metadata = save_config_to_constant_methods(
             self.config,
             self.generation_config,
-            **{"max_hidden_seq_length": max_hidden_seq_length},
+            **additional_configs,
         )
         self.exported_encoder = None
         self.exported_decoder = None

--- a/optimum/exporters/executorch/utils.py
+++ b/optimum/exporters/executorch/utils.py
@@ -34,6 +34,7 @@ def save_config_to_constant_methods(
         "get_vocab_size": config.vocab_size,
         "get_max_batch_size": 1,
         "get_max_seq_len": getattr(config, "max_position_embeddings", None),
+        "decoder_start_token_id": getattr(config, "decoder_start_token_id", None),
     }
 
     # Safely access fields from generation_config if it exists

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "optimum~=1.24",
     "executorch>=0.4.0,!=0.5.0",  # https://github.com/huggingface/optimum-executorch/issues/14
-    "transformers>=4.46,<4.49",
+    "transformers>=4.46,<=4.50.1",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
The fix in https://github.com/pytorch/executorch/pull/9507 is merged, which will unblock us working on some new models in `transformers`. Bump and test the latest version and squeeze some improvements:
 - fix hard-coded `decoder_start_token_id`
 - to be compatible with the upcoming `executorch==0.6.0`
 - version bump so that we can work on many new `transformers` models from latest releases
 - minor bug fix for passing config
 - support phi4 e2e with customized config (no "longrope" support atm)  (causing OOM, so have to disable in CI atm)