### PR TITLE
Support vision encoder models

### DIFF
--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -20,14 +20,22 @@ jobs:
           - common
           - albert
           - bert
+          - cvt
+          - deit
           - distilbert
+          - dit
+          - focalnet
           - gemma
           - gemma2
           - llama
+          - mobilevit
+          - mobilevit2
           - olmo
           - phi4
+          - pvt
           - qwen2
           - roberta
+          - swin
           - t5
         executorch-version: ['0.4.0', 'nightly']
         python-version: ['3.10', '3.11', '3.12']

--- a/README.md
+++ b/README.md
@@ -145,7 +145,15 @@ We currently support a wide range of popular transformer models, including encod
 - [T5](https://huggingface.co/google-t5/t5-small): Google's `T5` and its variants
 
 ### Vision Models
-🚀 Coming soon
+- [Cvt](https://huggingface.co/microsoft/cvt-13): Convolutional Vision Transformer
+- [Deit](https://huggingface.co/facebook/deit-base-distilled-patch16-224): Distilled Data-efficient Image Transformer (base-sized)
+- [Dit](https://huggingface.co/microsoft/dit-base-finetuned-rvlcdip): Document Image Transformer (base-sized)
+- [Focalnet](https://huggingface.co/microsoft/focalnet-tiny): FocalNet (tiny-sized)
+- [Mobilevit](https://huggingface.co/apple/mobilevit-xx-small): Apple's MobileViT xx-small
+- [Mobilevit2](https://huggingface.co/apple/mobilevitv2-1.0-imagenet1k-256): Apple's MobileViTv2
+- [Pvt](https://huggingface.co/Zetatech/pvt-tiny-224): Pyramid Vision Transformer (tiny-sized)
+- [Swin](https://huggingface.co/microsoft/swin-tiny-patch4-window7-224): Swin Transformer (tiny-sized)
+-🚀 Coming more soon...
 
 ### Audio Models
 🔊 Coming later

--- a/optimum/executorch/__init__.py
+++ b/optimum/executorch/__init__.py
@@ -20,6 +20,7 @@ from transformers.utils import _LazyModule
 _import_structure = {
     "modeling": [
         "ExecuTorchModelForCausalLM",
+        "ExecuTorchModelForImageClassification",
         "ExecuTorchModelForMaskedLM",
         "ExecuTorchModelForSeq2SeqLM",
     ],
@@ -28,6 +29,7 @@ _import_structure = {
 if TYPE_CHECKING:
     from .modeling import (
         ExecuTorchModelForCausalLM,
+        ExecuTorchModelForImageClassification,
         ExecuTorchModelForMaskedLM,
         ExecuTorchModelForSeq2SeqLM,
     )

--- a/optimum/exporters/executorch/recipes/xnnpack.py
+++ b/optimum/exporters/executorch/recipes/xnnpack.py
@@ -64,7 +64,9 @@ def export_to_executorch_with_xnnpack(
             et_progs[pte_name] = to_edge_transform_and_lower(
                 exported_program,
                 partitioner=[XnnpackPartitioner()],
-                compile_config=EdgeCompileConfig(_skip_dim_order=True),
+                compile_config=EdgeCompileConfig(
+                    _skip_dim_order=True,
+                ),
                 constant_methods=metadata,
             ).to_executorch(
                 config=ExecutorchBackendConfig(

--- a/optimum/exporters/executorch/tasks/__init__.py
+++ b/optimum/exporters/executorch/tasks/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import causal_lm, masked_lm, seq2seq_lm
+from . import causal_lm, image_classification, masked_lm, seq2seq_lm

--- a/optimum/exporters/executorch/tasks/image_classification.py
+++ b/optimum/exporters/executorch/tasks/image_classification.py
@@ -1,0 +1,42 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from transformers import AutoModelForImageClassification
+
+from ..integrations import VisionEncoderExportableModule
+from ..task_registry import register_task
+
+
+# NOTE: It’s important to map the registered task name to the pipeline name in https://github.com/huggingface/transformers/blob/main/utils/update_metadata.py.
+# This will streamline using inferred task names and make exporting models to Hugging Face pipelines easier.
+@register_task("image-classification")
+def load_image_classification_model(model_name_or_path: str, **kwargs) -> VisionEncoderExportableModule:
+    """
+    Loads a vision model for image classification and registers it under the task
+    'image-classification' using Hugging Face's `AutoModelForImageClassification`.
+
+    Args:
+        model_name_or_path (str):
+            Model ID on huggingface.co or path on disk to the model repository to export. For example:
+            `model_name_or_path="google/vit-base-patch16-224"` or `mode_name_or_path="/path/to/model_folder`
+        **kwargs:
+            Additional configuration options for the model.
+
+    Returns:
+        VisionEncoderExportableModule:
+            An instance of `VisionEncoderExportableModule` for exporting and lowering to ExecuTorch.
+    """
+
+    eager_model = AutoModelForImageClassification.from_pretrained(model_name_or_path, **kwargs).to("cpu").eval()
+    return VisionEncoderExportableModule(eager_model)

--- a/optimum/exporters/executorch/utils.py
+++ b/optimum/exporters/executorch/utils.py
@@ -24,14 +24,22 @@ def save_config_to_constant_methods(
     **kwargs,
 ):
     # Initialize metadata with values from model config
+    head_dim = None
+    if (
+        hasattr(config, "hidden_size")
+        and hasattr(config, "num_attention_heads")
+        and isinstance(config.num_attention_heads, int)
+    ):
+        head_dim = config.hidden_size / config.num_attention_heads
+
     metadata = {
         "get_dtype": 5 if config.torch_dtype == torch.float16 else 6,
         "get_bos_id": getattr(config, "bos_token_id", None),
         "get_eos_id": getattr(config, "eos_token_id", None),
-        "get_head_dim": config.hidden_size / config.num_attention_heads,
+        "get_head_dim": head_dim,
         "get_n_kv_heads": getattr(config, "num_key_value_heads", None),
-        "get_n_layers": config.num_hidden_layers,
-        "get_vocab_size": config.vocab_size,
+        "get_n_layers": getattr(config, "num_hidden_layers", None),
+        "get_vocab_size": getattr(config, "vocab_size", None),
         "get_max_batch_size": 1,
         "get_max_seq_len": getattr(config, "max_position_embeddings", None),
         "decoder_start_token_id": getattr(config, "decoder_start_token_id", None),

--- a/tests/models/test_modeling_cvt.py
+++ b/tests/models/test_modeling_cvt.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_cvt_export_to_executorch(self):
+        model_id = "microsoft/cvt-13"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_cvt_image_classification(self):
+        model_id = "microsoft/cvt-13"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_deit.py
+++ b/tests/models/test_modeling_deit.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_deit_export_to_executorch(self):
+        model_id = "facebook/deit-base-distilled-patch16-224"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_deit_image_classification(self):
+        model_id = "facebook/deit-base-distilled-patch16-224"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_dit.py
+++ b/tests/models/test_modeling_dit.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_dit_export_to_executorch(self):
+        model_id = "microsoft/dit-base-finetuned-rvlcdip"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_dit_image_classification(self):
+        model_id = "microsoft/dit-base-finetuned-rvlcdip"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_focalnet.py
+++ b/tests/models/test_modeling_focalnet.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_focalnet_export_to_executorch(self):
+        model_id = "microsoft/focalnet-tiny"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_focalnet_image_classification(self):
+        model_id = "microsoft/focalnet-tiny"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_gemma.py
+++ b/tests/models/test_modeling_gemma.py
@@ -64,4 +64,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             max_seq_len=21,
         )
         logging.info(f"\nGenerated text:\n\t{generated_text}")
+        # Free memory before loading eager for quality check
+        del model
+        del tokenizer
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_text))

--- a/tests/models/test_modeling_gemma2.py
+++ b/tests/models/test_modeling_gemma2.py
@@ -64,4 +64,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             max_seq_len=12,
         )
         logging.info(f"\nGenerated text:\n\t{generated_text}")
+        # Free memory before loading eager for quality check
+        del model
+        del tokenizer
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_text))

--- a/tests/models/test_modeling_mobilevit.py
+++ b/tests/models/test_modeling_mobilevit.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_mobilevit_export_to_executorch(self):
+        model_id = "apple/mobilevit-xx-small"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_mobilevit_image_classification(self):
+        model_id = "apple/mobilevit-xx-small"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_mobilevit2.py
+++ b/tests/models/test_modeling_mobilevit2.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_mobilevit2_export_to_executorch(self):
+        model_id = "apple/mobilevitv2-1.0-imagenet1k-256"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_mobilevit2_image_classification(self):
+        model_id = "apple/mobilevitv2-1.0-imagenet1k-256"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output, atol=1e-3, rtol=1e-3))

--- a/tests/models/test_modeling_pvt.py
+++ b/tests/models/test_modeling_pvt.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_pvt_export_to_executorch(self):
+        model_id = "Zetatech/pvt-tiny-224"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_pvt_image_classification(self):
+        model_id = "Zetatech/pvt-tiny-224"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_swin.py
+++ b/tests/models/test_modeling_swin.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_swin_export_to_executorch(self):
+        model_id = "microsoft/swin-tiny-patch4-window7-224"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_swin_image_classification(self):
+        model_id = "microsoft/swin-tiny-patch4-window7-224"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_vit.py
+++ b/tests/models/test_modeling_vit.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_vit_export_to_executorch(self):
+        model_id = "google/vit-base-patch16-224"
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_vit_image_classification(self):
+        model_id = "google/vit-base-patch16-224"
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))


### PR DESCRIPTION
Onboarded encoder-only vision transformers and test e2e with "image-classification" task.

- [Cvt](https://huggingface.co/microsoft/cvt-13): Convolutional Vision Transformer
- [Deit](https://huggingface.co/facebook/deit-base-distilled-patch16-224): Distilled Data-efficient Image Transformer (base-sized)
- [Dit](https://huggingface.co/microsoft/dit-base-finetuned-rvlcdip): Document Image Transformer (base-sized)
- [Focalnet](https://huggingface.co/microsoft/focalnet-tiny): FocalNet (tiny-sized)
- [Mobilevit](https://huggingface.co/apple/mobilevit-xx-small): Apple's MobileViT xx-small
- [Mobilevit2](https://huggingface.co/apple/mobilevitv2-1.0-imagenet1k-256): Apple's MobileViTv2
- [Pvt](https://huggingface.co/Zetatech/pvt-tiny-224): Pyramid Vision Transformer (tiny-sized)
- [Swin](https://huggingface.co/microsoft/swin-tiny-patch4-window7-224): Swin Transformer 