### PR TITLE
Add latency measurement for text models

### DIFF
--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -24,6 +24,7 @@ jobs:
           - deit
           - distilbert
           - dit
+          - efficientnet
           - focalnet
           - gemma
           - gemma2
@@ -35,8 +36,10 @@ jobs:
           - pvt
           - qwen2
           - roberta
+          - smollm
           - swin
           - t5
+          - vit
         executorch-version: ['0.4.0', 'nightly']
         python-version: ['3.10', '3.11', '3.12']
         os: [macos-15]
@@ -55,7 +58,7 @@ jobs:
       - name: Install dependencies for ExecuTorch
         run: |
           if [ "${{ matrix.executorch-version }}" == "nightly" ]; then
-            pip install executorch==0.7.0.dev20250330 --extra-index-url "https://download.pytorch.org/whl/nightly/cpu"
+            pip install executorch==0.7.0.dev20250403 --extra-index-url "https://download.pytorch.org/whl/nightly/cpu"
           else
             pip install executorch==${{ matrix.executorch-version }}
           fi

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ We currently support a wide range of popular transformer models, including encod
 - [Cvt](https://huggingface.co/microsoft/cvt-13): Convolutional Vision Transformer
 - [Deit](https://huggingface.co/facebook/deit-base-distilled-patch16-224): Distilled Data-efficient Image Transformer (base-sized)
 - [Dit](https://huggingface.co/microsoft/dit-base-finetuned-rvlcdip): Document Image Transformer (base-sized)
+- [EfficientNet](https://huggingface.co/google/efficientnet-b0): EfficientNet (b0-b7 sized)
 - [Focalnet](https://huggingface.co/microsoft/focalnet-tiny): FocalNet (tiny-sized)
 - [Mobilevit](https://huggingface.co/apple/mobilevit-xx-small): Apple's MobileViT xx-small
 - [Mobilevit2](https://huggingface.co/apple/mobilevitv2-1.0-imagenet1k-256): Apple's MobileViTv2

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -16,9 +16,10 @@
 
 import logging
 import os
+from abc import ABC, abstractmethod
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import torch
 from huggingface_hub import hf_hub_download
@@ -40,6 +41,7 @@ from ..exporters import TasksManager
 from ..exporters.executorch import main_export
 from ..modeling_base import FROM_PRETRAINED_START_DOCSTRING, OptimizedModel
 from ..utils.file_utils import find_files_matching_pattern
+from .stats import Stats
 
 
 _FILE_PATTERN = r".*\.pte$"
@@ -48,17 +50,16 @@ _FILE_PATTERN = r".*\.pte$"
 logger = logging.getLogger(__name__)
 
 
-class ExecuTorchModelForSeq2SeqLM(OptimizedModel):
+class ExecuTorchModelBase(OptimizedModel, ABC):
     """
-    ExecuTorch model with a seq2seq language modeling head for inference using the ExecuTorch Runtime.
+    ExecuTorch model for inference using the ExecuTorch Runtime.
 
-    This class provides an interface for loading, running, and generating outputs from a seq2seq language model
-    optimized for ExecuTorch Runtime. It includes utilities for exporting and loading pre-trained models
-    compatible with ExecuTorch runtime.
+    This class provides common interfaces and utilities for loading, running, and
+    generating outputs from models optimized for ExecuTorch Runtime.
 
     Attributes:
         auto_model_class (`Type`):
-            Associated Transformers class, `AutoModelForSeq2SeqLM`.
+            Associated Transformers class, `AutoModelForXXX`, must be set in derived classes.
         model (`ExecuTorchModule`):
             The loaded ExecuTorch model.
         use_kv_cache (`bool`):
@@ -78,45 +79,192 @@ class ExecuTorchModelForSeq2SeqLM(OptimizedModel):
             Size of the model vocabulary.
     """
 
-    auto_model_class = AutoModelForSeq2SeqLM
+    auto_model_class = None
 
-    def __init__(self, encoder: "ExecuTorchModule", decoder: "ExecuTorchModule", config: "PretrainedConfig"):
+    def __init__(self, models: Dict[str, "ExecuTorchModule"], config: "PretrainedConfig"):
         super().__init__(model=None, config=config)
-        self.et_encoder = encoder
-        self.et_decoder = decoder
-        metadata = self.et_decoder.method_names()
-        if "use_kv_cache" in metadata:
-            self.use_kv_cache = self.et_decoder.run_method("use_kv_cache")[0]
-        if "get_max_seq_len" in metadata:
-            self.max_cache_size = self.et_decoder.run_method("get_max_seq_len")[0]
-        if "get_max_batch_size" in metadata:
-            self.max_batch_size = self.et_decoder.run_method("get_max_batch_size")[0]
-        if "get_dtype" in metadata:
-            self.dtype = self.et_decoder.run_method("get_dtype")[0]
-        if "get_bos_id" in metadata:
-            self.bos_token_id = self.et_decoder.run_method("get_bos_id")[0]
-        if "get_eos_id" in metadata:
-            self.eos_token_id = self.et_decoder.run_method("get_eos_id")[0]
-        if "get_vocab_size" in metadata:
-            self.vocab_size = self.et_decoder.run_method("get_vocab_size")[0]
-        if "max_hidden_seq_length" in metadata:
-            self.max_hidden_seq_length = self.et_decoder.run_method("max_hidden_seq_length")[0]
-        if "decoder_start_token_id" in metadata:
-            self.decoder_start_token_id = self.et_decoder.run_method("decoder_start_token_id")[0]
 
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        decoder_input_ids: torch.Tensor,
-        cache_position: torch.Tensor,
-        encoder_outputs: Optional[torch.Tensor] = None,
+        if self.__class__.auto_model_class is None:
+            raise ValueError(
+                f"Class {self.__class__.__name__} must set auto_model_class. "
+                f"This attribute is used to identify the corresponding AutoModel class."
+            )
+
+        for key, value in models.items():
+            setattr(self, key, value)
+
+        self.stats = Stats()
+
+    @abstractmethod
+    def forward(self, *args, **kwargs):
+        """
+        Forward pass of the model.
+        Must be implemented by all derived classes.
+        """
+        pass
+
+    @abstractmethod
+    def generate(self, *args, **kwargs):
+        """
+        Generate tokens from input.
+        Must be implemented by all derived classes.
+        """
+        pass
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_id: Union[str, Path],
+        config: Optional[PretrainedConfig] = None,
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        subfolder: str = "",
+        force_download: bool = False,
+        local_files_only: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        file_name: Optional[str] = None,
+        **kwargs,
+    ) -> Dict[str, "ExecuTorchModule"]:
+        if isinstance(model_id, Path):
+            model_id = model_id.as_posix()
+
+        _PTE_SUFFIX = ".pte"
+        if file_name and not file_name.endswith(_PTE_SUFFIX):
+            raise ValueError(f"Invalid file name: {file_name}. Expected a '{_PTE_SUFFIX}' file.")
+
+        default_file_name = file_name or "model.pte"
+
+        pte_files = find_files_matching_pattern(
+            model_id,
+            _FILE_PATTERN,
+            glob_pattern="**/*.pte",
+            subfolder=subfolder,
+            token=token,
+            revision=revision,
+        )
+
+        if len(pte_files) == 0:
+            raise FileNotFoundError(f"Could not find any ExecuTorch model file in {model_id}")
+        if len(pte_files) == 1 and file_name and file_name != pte_files[0].name:
+            raise FileNotFoundError(f"Trying to load {file_name} but only found {pte_files[0].name}")
+
+        file_name = pte_files[0].name
+        subfolder = pte_files[0].parent
+
+        if len(pte_files) > 1:
+            for file in pte_files:
+                if file.name == default_file_name:
+                    file_name = file.name
+                    subfolder = file.parent
+                    break
+
+            logger.warning(
+                f"Too many ExecuTorch model files were found in {' ,'.join(map(str, pte_files))}. "
+                "specify which one to load by using the `file_name` and/or the `subfolder` arguments. "
+                f"Loading the file {file_name} in the subfolder {subfolder}."
+            )
+
+        if os.path.isdir(model_id):
+            model_id = subfolder
+            subfolder = ""
+
+        model_cache_path = cls._cached_file(
+            model_path=model_id,
+            token=token,
+            revision=revision,
+            force_download=force_download,
+            cache_dir=cache_dir,
+            file_name=default_file_name,
+            subfolder=subfolder,
+            local_files_only=local_files_only,
+        )
+        model = _load_for_executorch(model_cache_path)
+        logging.info(f"Loaded model from {model_cache_path}")
+
+        return {default_file_name.removesuffix(_PTE_SUFFIX): model}
+
+    @staticmethod
+    def _cached_file(
+        model_path: Union[Path, str],
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        force_download: bool = False,
+        cache_dir: Optional[str] = None,
+        file_name: Optional[str] = None,
+        subfolder: str = "",
+        local_files_only: bool = False,
     ):
-        # Encode if needed (first prediction pass)
-        is_first_prediction = encoder_outputs is None
-        if is_first_prediction:
-            encoder_outputs = self.et_encoder.forward((input_ids,))[0]
+        model_path = Path(model_path)
+        # locates a file in a local folder and repo, downloads and cache it if necessary.
+        if model_path.is_dir():
+            model_cache_path = os.path.join(model_path, subfolder, file_name)
+        else:
+            model_cache_path = hf_hub_download(
+                repo_id=model_path.as_posix(),
+                filename=file_name,
+                subfolder=subfolder,
+                token=token,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                local_files_only=local_files_only,
+            )
 
-        return (self.et_decoder.forward((decoder_input_ids, encoder_outputs, cache_position))[0], encoder_outputs)
+        return model_cache_path
+
+    @classmethod
+    def _export(
+        cls,
+        model_id: str,
+        recipe: str,
+        config: Optional[PretrainedConfig] = None,
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        trust_remote_code: bool = False,
+        subfolder: str = "",
+        force_download: bool = False,
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Dict[str, "ExecuTorchModule"]:
+        task = kwargs.pop("task", None)
+        if task is not None:
+            logger.warning(f"task was provided and set to {task} but not used, will be ignored")
+        inferred_task = TasksManager.infer_task_from_model(cls.auto_model_class)
+        logging.info(f"Inferred task from model class: {inferred_task}")
+
+        save_dir = TemporaryDirectory()
+        save_dir_path = Path(save_dir.name)
+
+        # Export to ExecuTorch and save the pte file to the temporary directory
+        executorch_progs = main_export(
+            model_name_or_path=model_id,
+            output_dir=save_dir_path,
+            task=inferred_task,
+            recipe=recipe,
+            config=config,
+            subfolder=subfolder,
+            revision=revision,
+            cache_dir=cache_dir,
+            token=token,
+            local_files_only=local_files_only,
+            force_download=force_download,
+            trust_remote_code=trust_remote_code,
+            **kwargs,
+        )
+
+        models = {}
+        for name, _ in executorch_progs.items():
+            models.update(cls._from_pretrained(save_dir_path, file_name=f"{name}.pte", config=config))
+
+        return models
+
+    def _save_pretrained(self, save_directory):
+        """
+        Saves a model weights into a directory, so that it can be re-loaded using the
+        [`from_pretrained`] class method.
+        """
+        raise NotImplementedError
 
     @classmethod
     @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)
@@ -133,7 +281,7 @@ class ExecuTorchModelForSeq2SeqLM(OptimizedModel):
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
         config: Optional[PretrainedConfig] = None,
         **kwargs,
-    ):
+    ) -> "ExecuTorchModelBase":
         if isinstance(model_id, Path):
             model_id = model_id.as_posix()
 
@@ -180,9 +328,9 @@ class ExecuTorchModelForSeq2SeqLM(OptimizedModel):
                 f"Could not infer whether the model was already converted or not to the ExecuTorch IR, keeping `export={export}`.\n{exception}"
             )
 
-        from_pretrained_method = cls._export if _export else cls._from_multiple_pretrained
+        from_pretrained_method = cls._export if _export else cls._from_pretrained
 
-        return from_pretrained_method(
+        models_dict = from_pretrained_method(
             model_id=model_id,
             config=config,
             revision=revision,
@@ -195,156 +343,84 @@ class ExecuTorchModelForSeq2SeqLM(OptimizedModel):
             **kwargs,
         )
 
-    @classmethod
-    def _from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        config: PretrainedConfig,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        file_name: Optional[str] = None,
-        **kwargs,
-    ) -> "ExecuTorchModule":
-        if isinstance(model_id, Path):
-            model_id = model_id.as_posix()
+        return cls(models_dict, config)
 
-        default_file_name = file_name or "model.pte"
 
-        pte_files = find_files_matching_pattern(
-            model_id,
-            _FILE_PATTERN,
-            glob_pattern="**/*.pte",
-            subfolder=subfolder,
-            token=token,
-            revision=revision,
-        )
+class ExecuTorchModelForSeq2SeqLM(ExecuTorchModelBase):
+    """
+    ExecuTorch model with a seq2seq language modeling head for inference using the ExecuTorch Runtime.
 
-        if len(pte_files) == 0:
-            raise FileNotFoundError(f"Could not find any ExecuTorch model file in {model_id}")
-        if len(pte_files) == 1 and file_name and file_name != pte_files[0].name:
-            raise FileNotFoundError(f"Trying to load {file_name} but only found {pte_files[0].name}")
+    This class provides an interface for loading, running, and generating outputs from a seq2seq language model
+    optimized for ExecuTorch Runtime. It includes utilities for exporting and loading pre-trained models
+    compatible with ExecuTorch runtime.
 
-        file_name = pte_files[0].name
-        subfolder = pte_files[0].parent
+    Attributes:
+        auto_model_class (`Type`):
+            Associated Transformers class, `AutoModelForSeq2SeqLM`.
+        model (`ExecuTorchModule`):
+            The loaded ExecuTorch model.
+        use_kv_cache (`bool`):
+            Whether key-value caching is enabled. For performance reasons, the exported model is
+            optimized to use a static cache.
+        max_cache_size (`int`):
+            Maximum sequence length supported by the cache.
+        max_batch_size (`int`):
+            Maximum supported batch size.
+        dtype (`str`):
+            Data type of the model parameters.
+        bos_token_id (`int`):
+            Beginning-of-sequence token ID.
+        eos_token_id (`int`):
+            End-of-sequence token ID.
+        vocab_size (`int`):
+            Size of the model vocabulary.
+    """
 
-        if len(pte_files) > 1:
-            for file in pte_files:
-                if file.name == default_file_name:
-                    file_name = file.name
-                    subfolder = file.parent
-                    break
+    auto_model_class = AutoModelForSeq2SeqLM
 
-        if os.path.isdir(model_id):
-            model_id = subfolder
-            subfolder = ""
+    def __init__(self, models: Dict[str, "ExecuTorchModule"], config: "PretrainedConfig"):
+        super().__init__(models=models, config=config)
+        if not hasattr(self, "encoder"):
+            raise AttributeError("Expected attribute 'encoder' not found in the instance.")
+        if not hasattr(self, "decoder"):
+            raise AttributeError("Expected attribute 'decoder' not found in the instance.")
+        metadata = self.decoder.method_names()
+        if "use_kv_cache" in metadata:
+            self.use_kv_cache = self.decoder.run_method("use_kv_cache")[0]
+        if "get_max_seq_len" in metadata:
+            self.max_cache_size = self.decoder.run_method("get_max_seq_len")[0]
+        if "get_max_batch_size" in metadata:
+            self.max_batch_size = self.decoder.run_method("get_max_batch_size")[0]
+        if "get_dtype" in metadata:
+            self.dtype = self.decoder.run_method("get_dtype")[0]
+        if "get_bos_id" in metadata:
+            self.bos_token_id = self.decoder.run_method("get_bos_id")[0]
+        if "get_eos_id" in metadata:
+            self.eos_token_id = self.decoder.run_method("get_eos_id")[0]
+        if "get_vocab_size" in metadata:
+            self.vocab_size = self.decoder.run_method("get_vocab_size")[0]
+        if "max_hidden_seq_length" in metadata:
+            self.max_hidden_seq_length = self.decoder.run_method("max_hidden_seq_length")[0]
+        if "decoder_start_token_id" in metadata:
+            self.decoder_start_token_id = self.decoder.run_method("decoder_start_token_id")[0]
 
-        model_cache_path = cls._cached_file(
-            model_path=model_id,
-            token=token,
-            revision=revision,
-            force_download=force_download,
-            cache_dir=cache_dir,
-            file_name=default_file_name,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-        )
-        et_model = _load_for_executorch(model_cache_path)
-        logging.info(f"Loaded model from {model_cache_path}")
-
-        return et_model
-
-    @classmethod
-    def _from_multiple_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        config: PretrainedConfig,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        file_name: Optional[str] = None,
-        **kwargs,
-    ) -> "ExecuTorchModelForSeq2SeqLM":
-        et_encoder = cls._from_pretrained(model_id, file_name="encoder.pte", config=config)
-        et_decoder = cls._from_pretrained(model_id, file_name="decoder.pte", config=config)
-        return cls(et_encoder, et_decoder, config)
-
-    @staticmethod
-    def _cached_file(
-        model_path: Union[Path, str],
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: Optional[str] = None,
-        file_name: Optional[str] = None,
-        subfolder: str = "",
-        local_files_only: bool = False,
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        decoder_input_ids: torch.Tensor,
+        cache_position: torch.Tensor,
+        encoder_outputs: Optional[torch.Tensor] = None,
     ):
-        model_path = Path(model_path)
-        # locates a file in a local folder and repo, downloads and cache it if necessary.
-        if model_path.is_dir():
-            model_cache_path = os.path.join(model_path, subfolder, file_name)
-        else:
-            model_cache_path = hf_hub_download(
-                repo_id=model_path.as_posix(),
-                filename=file_name,
-                subfolder=subfolder,
-                token=token,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                local_files_only=local_files_only,
-            )
+        # Encode if needed (first prediction pass)
+        is_first_prediction = encoder_outputs is None
+        self.stats.on_model_execution_start()
+        if is_first_prediction:
+            encoder_outputs = self.encoder.forward((input_ids,))[0]
+            self.stats.on_prompt_eval_end()
 
-        return model_cache_path
-
-    @classmethod
-    def _export(
-        cls,
-        model_id: str,
-        recipe: str,
-        config: PretrainedConfig,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        trust_remote_code: bool = False,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        **kwargs,
-    ):
-        save_dir = TemporaryDirectory()
-        save_dir_path = Path(save_dir.name)
-
-        # Export to ExecuTorch and save the pte file to the temporary directory
-        main_export(
-            model_name_or_path=model_id,
-            output_dir=save_dir_path,
-            task="text2text-generation",
-            recipe=recipe,
-            subfolder=subfolder,
-            revision=revision,
-            cache_dir=cache_dir,
-            token=token,
-            local_files_only=local_files_only,
-            force_download=force_download,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )
-        return cls._from_multiple_pretrained(model_id=save_dir_path, config=config)
-
-    def _save_pretrained(self, save_directory):
-        """
-        Saves a model weights into a directory, so that it can be re-loaded using the
-        [`from_pretrained`] class method.
-        """
-        raise NotImplementedError
+        result = (self.decoder.forward((decoder_input_ids, encoder_outputs, cache_position))[0], encoder_outputs)
+        self.stats.on_model_execution_end()
+        return result
 
     def generate(
         self,
@@ -392,17 +468,25 @@ class ExecuTorchModelForSeq2SeqLM(OptimizedModel):
         encoder_outputs = None
         generated_ids = [0]
 
+        first_token_generated = False
+
         # Generate tokens one by one
         for i in range(max_seq_len - 1):
             # Run decoder for next token prediction
             cache_position = torch.tensor([i], dtype=torch.long)
+            self.stats.on_sampling_begin()
             logits, encoder_outputs = self.forward(
                 encoder_input_ids, decoder_input_ids, cache_position, encoder_outputs
             )
+            self.stats.on_sampling_end()
+            if not first_token_generated:
+                self.stats.on_first_token()
+                first_token_generated = True
 
             # Get next token
             next_token = torch.argmax(logits[:, -1, :], dim=-1).item()
             generated_ids.append(next_token)
+            self.stats.set_num_generated_tokens(len(generated_ids) - 1)  # Don't count decoder_start_token
 
             # Update input for next iteration
             decoder_input_ids = torch.tensor([[next_token]], dtype=torch.long)
@@ -436,15 +520,29 @@ class ExecuTorchModelForSeq2SeqLM(OptimizedModel):
                 Will be truncated to maximal cache size if larger than `max_cache_size`.
         """
         self.tokenizer = tokenizer
+
+        # Reset stats for a new generation
+        self.stats.reset()
+        self.stats.on_inference_start()
+
+        # Tokenization is part of inference
+        input_ids = self.tokenizer(prompt, return_tensors="pt").input_ids
+        self.stats.on_token_encode_end()
+        self.stats.set_num_prompt_tokens(input_ids.size(1))
+
         generated_tokens = self.generate(
-            input_ids=self.tokenizer(prompt, return_tensors="pt").input_ids,
+            input_ids=input_ids,
             echo=echo,
             max_seq_len=max_seq_len,
         )
+
+        self.stats.on_inference_end()
+        self.stats.print_report()
+
         return self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
 
 
-class ExecuTorchModelForCausalLM(OptimizedModel):
+class ExecuTorchModelForCausalLM(ExecuTorchModelBase):
     """
     ExecuTorch model with a causal language modeling head for inference using the ExecuTorch Runtime.
 
@@ -476,10 +574,12 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
 
     auto_model_class = AutoModelForCausalLM
 
-    def __init__(self, model: "ExecuTorchModule", config: "PretrainedConfig"):
-        super().__init__(model, config)
+    def __init__(self, models: Dict[str, "ExecuTorchModule"], config: "PretrainedConfig"):
+        super().__init__(models, config)
+        if not hasattr(self, "model"):
+            raise AttributeError("Expected attribute 'model' not found in the instance.")
         metadata = self.model.method_names()
-        logging.info(f"Load all static methods: {metadata}")
+        logging.debug(f"Load all static methods: {metadata}")
         if "use_kv_cache" in metadata:
             self.use_kv_cache = self.model.run_method("use_kv_cache")[0]
         if "get_max_seq_len" in metadata:
@@ -510,151 +610,10 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
         Returns:
             torch.Tensor: Logits output from the model.
         """
-        return self.model.forward((input_ids, cache_position))[0]
-
-    @classmethod
-    def _from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        config: Optional[PretrainedConfig] = None,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        file_name: Optional[str] = None,
-        **kwargs,
-    ) -> "ExecuTorchModelForCausalLM":
-        if isinstance(model_id, Path):
-            model_id = model_id.as_posix()
-
-        default_file_name = file_name or "model.pte"
-
-        pte_files = find_files_matching_pattern(
-            model_id,
-            _FILE_PATTERN,
-            glob_pattern="**/*.pte",
-            subfolder=subfolder,
-            token=token,
-            revision=revision,
-        )
-
-        if len(pte_files) == 0:
-            raise FileNotFoundError(f"Could not find any ExecuTorch model file in {model_id}")
-        if len(pte_files) == 1 and file_name and file_name != pte_files[0].name:
-            raise FileNotFoundError(f"Trying to load {file_name} but only found {pte_files[0].name}")
-
-        file_name = pte_files[0].name
-        subfolder = pte_files[0].parent
-
-        if len(pte_files) > 1:
-            for file in pte_files:
-                if file.name == default_file_name:
-                    file_name = file.name
-                    subfolder = file.parent
-                    break
-
-            logger.warning(
-                f"Too many ExecuTorch model files were found in {' ,'.join(map(str, pte_files))}. "
-                "specify which one to load by using the `file_name` and/or the `subfolder` arguments. "
-                f"Loading the file {file_name} in the subfolder {subfolder}."
-            )
-
-        if os.path.isdir(model_id):
-            model_id = subfolder
-            subfolder = ""
-
-        model_cache_path = cls._cached_file(
-            model_path=model_id,
-            token=token,
-            revision=revision,
-            force_download=force_download,
-            cache_dir=cache_dir,
-            file_name=default_file_name,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-        )
-        model = _load_for_executorch(model_cache_path)
-        logging.info(f"Loaded model from {model_cache_path}")
-
-        return cls(model, config=config)
-
-    @staticmethod
-    def _cached_file(
-        model_path: Union[Path, str],
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: Optional[str] = None,
-        file_name: Optional[str] = None,
-        subfolder: str = "",
-        local_files_only: bool = False,
-    ):
-        model_path = Path(model_path)
-        # locates a file in a local folder and repo, downloads and cache it if necessary.
-        if model_path.is_dir():
-            model_cache_path = os.path.join(model_path, subfolder, file_name)
-        else:
-            model_cache_path = hf_hub_download(
-                repo_id=model_path.as_posix(),
-                filename=file_name,
-                subfolder=subfolder,
-                token=token,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                local_files_only=local_files_only,
-            )
-
-        return model_cache_path
-
-    @classmethod
-    def _export(
-        cls,
-        model_id: str,
-        recipe: str,
-        config: Optional[PretrainedConfig] = None,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        trust_remote_code: bool = False,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        **kwargs,
-    ):
-        task = kwargs.pop("task", None)
-        if task is not None:
-            logger.warning(f"task was provided and set to {task} but not used, will be ignored")
-
-        save_dir = TemporaryDirectory()
-        save_dir_path = Path(save_dir.name)
-
-        # Export to ExecuTorch and save the pte file to the temporary directory
-        main_export(
-            model_name_or_path=model_id,
-            output_dir=save_dir_path,
-            task=TasksManager.infer_task_from_model(cls.auto_model_class),
-            recipe=recipe,
-            config=config,
-            subfolder=subfolder,
-            revision=revision,
-            cache_dir=cache_dir,
-            token=token,
-            local_files_only=local_files_only,
-            force_download=force_download,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )
-        return cls._from_pretrained(model_id=save_dir_path, config=config)
-
-    def _save_pretrained(self, save_directory):
-        """
-        Saves a model weights into a directory, so that it can be re-loaded using the
-        [`from_pretrained`] class method.
-        """
-        raise NotImplementedError
+        self.stats.on_model_execution_start()
+        logits = self.model.forward((input_ids, cache_position))[0]
+        self.stats.on_model_execution_end()
+        return logits
 
     def generate(
         self,
@@ -698,15 +657,21 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
 
         # prefill
         for i, prompt_token in enumerate(prompt_tokens):
+            self.stats.on_sampling_begin()
             logits = self.forward(
                 input_ids=torch.tensor([prompt_token], dtype=torch.long, device=self.device).unsqueeze(0),
                 cache_position=torch.tensor([i], dtype=torch.long, device=self.device),
             )
+            self.stats.on_sampling_end()
+
+        self.stats.on_prompt_eval_end()
+        first_token_generated = False
 
         next_token = torch.argmax(logits, dim=-1).item()
         generated_tokens = prompt_tokens + [next_token]
 
         while len(generated_tokens) < max_seq_len:
+            self.stats.on_sampling_begin()
             logits = self.forward(
                 input_ids=torch.tensor([next_token], dtype=torch.long, device=self.device).unsqueeze(0),
                 cache_position=torch.tensor(
@@ -715,10 +680,18 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
                     device=self.device,
                 ),
             )
+            self.stats.on_sampling_end()
+            if not first_token_generated:
+                self.stats.on_first_token()
+                first_token_generated = True
+
             next_token = torch.argmax(logits, dim=-1).item()
             generated_tokens.append(next_token)
+
             if next_token == self.eos_token_id:
                 break
+
+        self.stats.set_num_generated_tokens(len(generated_tokens) - len(prompt_tokens))
 
         return generated_tokens if echo else generated_tokens[len(prompt_tokens) :]
 
@@ -756,93 +729,27 @@ class ExecuTorchModelForCausalLM(OptimizedModel):
                 f"The tokenizer's eos_token_id={self.tokenizer.eos_token_id} must be the same as the model's eos_token_id={self.eos_token_id}."
             )
 
+        # Reset stats for a new generation
+        self.stats.reset()
+        self.stats.on_inference_start()
+
         prompt_tokens = self.tokenizer.encode(prompt)
+        self.stats.on_token_encode_end()
+        self.stats.set_num_prompt_tokens(len(prompt_tokens))
+
         generated_tokens = self.generate(
             prompt_tokens=prompt_tokens,
             echo=echo,
             max_seq_len=max_seq_len,
         )
+
+        self.stats.on_inference_end()
+        self.stats.print_report()
+
         return self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
 
-    @classmethod
-    @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)
-    def from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        export: bool = False,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        trust_remote_code: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        config: Optional[PretrainedConfig] = None,
-        **kwargs,
-    ):
-        if isinstance(model_id, Path):
-            model_id = model_id.as_posix()
 
-        if is_offline_mode() and not local_files_only:
-            logger.info("Offline mode: setting `local_files_only=True`")
-            local_files_only = True
-
-        _export = export
-        try:
-            if local_files_only and not os.path.isdir(model_id):
-                object_id = model_id.replace("/", "--")
-                cached_model_dir = os.path.join(cache_dir, f"models--{object_id}")
-                refs_file = os.path.join(os.path.join(cached_model_dir, "refs"), revision or "main")
-                with open(refs_file) as f:
-                    _revision = f.read()
-                model_dir = os.path.join(cached_model_dir, "snapshots", _revision)
-            else:
-                model_dir = model_id
-
-            pte_files = find_files_matching_pattern(
-                model_dir,
-                pattern=_FILE_PATTERN,
-                glob_pattern="**/*.pte",
-                subfolder=subfolder,
-                token=token,
-                revision=revision,
-            )
-
-            _export = len(pte_files) == 0
-            if _export ^ export:
-                if export:
-                    logger.warning(
-                        f"The model {model_id} was already converted to the ExecuTorch IR but got `export=True`, the model will be converted to ExecuTorch once again. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
-                    )
-                    _export = True
-                else:
-                    logger.warning(
-                        f"No ExecuTorch files were found for {model_id}, setting `export=True` to convert the model to the ExecuTorch IR. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
-                    )
-        except Exception as exception:
-            logger.warning(
-                f"Could not infer whether the model was already converted or not to the ExecuTorch IR, keeping `export={export}`.\n{exception}"
-            )
-
-        from_pretrained_method = cls._export if _export else cls._from_pretrained
-
-        return from_pretrained_method(
-            model_id=model_id,
-            config=config,
-            revision=revision,
-            cache_dir=cache_dir,
-            force_download=force_download,
-            token=token,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )
-
-
-class ExecuTorchModelForMaskedLM(OptimizedModel):
+class ExecuTorchModelForMaskedLM(ExecuTorchModelBase):
     """
     ExecuTorch model with a masked language modeling head for inference using the ExecuTorch Runtime.
 
@@ -855,13 +762,6 @@ class ExecuTorchModelForMaskedLM(OptimizedModel):
             Associated Transformers class, `AutoModelForMaskedLM`.
         model (`ExecuTorchModule`):
             The loaded ExecuTorch model.
-        use_kv_cache (`bool`):
-            Whether key-value caching is enabled. For performance reasons, the exported model is
-            optimized to use a static cache.
-        max_cache_size (`int`):
-            Maximum sequence length supported by the cache.
-        max_batch_size (`int`):
-            Maximum supported batch size.
         dtype (`str`):
             Data type of the model parameters.
         bos_token_id (`int`):
@@ -874,8 +774,10 @@ class ExecuTorchModelForMaskedLM(OptimizedModel):
 
     auto_model_class = AutoModelForMaskedLM
 
-    def __init__(self, model: "ExecuTorchModule", config: "PretrainedConfig"):
-        super().__init__(model, config)
+    def __init__(self, models: Dict[str, "ExecuTorchModule"], config: "PretrainedConfig"):
+        super().__init__(models, config)
+        if not hasattr(self, "model"):
+            raise AttributeError("Expected attribute 'model' not found in the instance.")
         metadata = self.model.method_names()
         logging.debug(f"Load all static methods: {metadata}")
         if "get_max_seq_len" in metadata:
@@ -906,226 +808,28 @@ class ExecuTorchModelForMaskedLM(OptimizedModel):
         Returns:
             torch.Tensor: Logits output from the model.
         """
-        return self.model.forward((input_ids, attention_mask))[0]
+        # Reset stats for a new generation
+        self.stats.reset()
+        # Set number of prompt tokens (total tokens for MaskedLM)
+        self.stats.set_num_prompt_tokens(input_ids.size(1))
 
-    @classmethod
-    def _from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        config: PretrainedConfig,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        file_name: Optional[str] = None,
-        **kwargs,
-    ) -> "ExecuTorchModelForMaskedLM":
-        if isinstance(model_id, Path):
-            model_id = model_id.as_posix()
+        self.stats.on_inference_start()
+        self.stats.on_prompt_eval_end()
+        self.stats.on_sampling_begin()
+        self.stats.on_model_execution_start()
+        logits = self.model.forward((input_ids, attention_mask))[0]
+        self.stats.on_model_execution_end()
+        self.stats.on_sampling_end()
+        self.stats.on_first_token()
+        self.stats.on_inference_end()
+        self.stats.print_report()
+        return logits
 
-        default_file_name = file_name or "model.pte"
-
-        pte_files = find_files_matching_pattern(
-            model_id,
-            _FILE_PATTERN,
-            glob_pattern="**/*.pte",
-            subfolder=subfolder,
-            token=token,
-            revision=revision,
-        )
-
-        if len(pte_files) == 0:
-            raise FileNotFoundError(f"Could not find any ExecuTorch model file in {model_id}")
-        if len(pte_files) == 1 and file_name and file_name != pte_files[0].name:
-            raise FileNotFoundError(f"Trying to load {file_name} but only found {pte_files[0].name}")
-
-        file_name = pte_files[0].name
-        subfolder = pte_files[0].parent
-
-        if len(pte_files) > 1:
-            for file in pte_files:
-                if file.name == default_file_name:
-                    file_name = file.name
-                    subfolder = file.parent
-                    break
-
-            logger.warning(
-                f"Too many ExecuTorch model files were found in {' ,'.join(map(str, pte_files))}. "
-                "specify which one to load by using the `file_name` and/or the `subfolder` arguments. "
-                f"Loading the file {file_name} in the subfolder {subfolder}."
-            )
-
-        if os.path.isdir(model_id):
-            model_id = subfolder
-            subfolder = ""
-
-        model_cache_path = cls._cached_file(
-            model_path=model_id,
-            token=token,
-            revision=revision,
-            force_download=force_download,
-            cache_dir=cache_dir,
-            file_name=default_file_name,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-        )
-        model = _load_for_executorch(model_cache_path)
-        logging.info(f"Loaded model from {model_cache_path}")
-
-        return cls(model, config=config)
-
-    @staticmethod
-    def _cached_file(
-        model_path: Union[Path, str],
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: Optional[str] = None,
-        file_name: Optional[str] = None,
-        subfolder: str = "",
-        local_files_only: bool = False,
-    ):
-        model_path = Path(model_path)
-        # locates a file in a local folder and repo, downloads and cache it if necessary.
-        if model_path.is_dir():
-            model_cache_path = os.path.join(model_path, subfolder, file_name)
-        else:
-            model_cache_path = hf_hub_download(
-                repo_id=model_path.as_posix(),
-                filename=file_name,
-                subfolder=subfolder,
-                token=token,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                local_files_only=local_files_only,
-            )
-
-        return model_cache_path
-
-    @classmethod
-    def _export(
-        cls,
-        model_id: str,
-        recipe: str,
-        config: PretrainedConfig,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        trust_remote_code: bool = False,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        **kwargs,
-    ):
-        save_dir = TemporaryDirectory()
-        save_dir_path = Path(save_dir.name)
-
-        # Export to ExecuTorch and save the pte file to the temporary directory
-        main_export(
-            model_name_or_path=model_id,
-            output_dir=save_dir_path,
-            task="fill-mask",
-            recipe=recipe,
-            subfolder=subfolder,
-            revision=revision,
-            cache_dir=cache_dir,
-            token=token,
-            local_files_only=local_files_only,
-            force_download=force_download,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )
-        return cls._from_pretrained(model_id=save_dir_path, config=config)
-
-    def _save_pretrained(self, save_directory):
-        """
-        Saves a model weights into a directory, so that it can be re-loaded using the
-        [`from_pretrained`] class method.
-        """
+    def generate(self):
         raise NotImplementedError
 
-    @classmethod
-    @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)
-    def from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        export: bool = False,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        trust_remote_code: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        config: Optional[PretrainedConfig] = None,
-        **kwargs,
-    ):
-        if isinstance(model_id, Path):
-            model_id = model_id.as_posix()
 
-        if is_offline_mode() and not local_files_only:
-            logger.info("Offline mode: setting `local_files_only=True`")
-            local_files_only = True
-
-        _export = export
-        try:
-            if local_files_only and not os.path.isdir(model_id):
-                object_id = model_id.replace("/", "--")
-                cached_model_dir = os.path.join(cache_dir, f"models--{object_id}")
-                refs_file = os.path.join(os.path.join(cached_model_dir, "refs"), revision or "main")
-                with open(refs_file) as f:
-                    _revision = f.read()
-                model_dir = os.path.join(cached_model_dir, "snapshots", _revision)
-            else:
-                model_dir = model_id
-
-            pte_files = find_files_matching_pattern(
-                model_dir,
-                pattern=_FILE_PATTERN,
-                glob_pattern="**/*.pte",
-                subfolder=subfolder,
-                token=token,
-                revision=revision,
-            )
-
-            _export = len(pte_files) == 0
-            if _export ^ export:
-                if export:
-                    logger.warning(
-                        f"The model {model_id} was already converted to the ExecuTorch IR but got `export=True`, the model will be converted to ExecuTorch once again. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
-                    )
-                    _export = True
-                else:
-                    logger.warning(
-                        f"No ExecuTorch files were found for {model_id}, setting `export=True` to convert the model to the ExecuTorch IR. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
-                    )
-        except Exception as exception:
-            logger.warning(
-                f"Could not infer whether the model was already converted or not to the ExecuTorch IR, keeping `export={export}`.\n{exception}"
-            )
-
-        from_pretrained_method = cls._export if _export else cls._from_pretrained
-
-        return from_pretrained_method(
-            model_id=model_id,
-            config=config,
-            revision=revision,
-            cache_dir=cache_dir,
-            force_download=force_download,
-            token=token,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )
-
-
-class ExecuTorchModelForImageClassification(OptimizedModel):
+class ExecuTorchModelForImageClassification(ExecuTorchModelBase):
     """
     ExecuTorch model with an image classification head for inference using the ExecuTorch Runtime.
 
@@ -1138,27 +842,14 @@ class ExecuTorchModelForImageClassification(OptimizedModel):
             Associated Transformers class, `AutoModelForImageClassification`.
         model (`ExecuTorchModule`):
             The loaded ExecuTorch model.
-        use_kv_cache (`bool`):
-            Whether key-value caching is enabled. For performance reasons, the exported model is
-            optimized to use a static cache.
-        max_cache_size (`int`):
-            Maximum sequence length supported by the cache.
-        max_batch_size (`int`):
-            Maximum supported batch size.
-        dtype (`str`):
-            Data type of the model parameters.
-        bos_token_id (`int`):
-            Beginning-of-sequence token ID.
-        eos_token_id (`int`):
-            End-of-sequence token ID.
-        vocab_size (`int`):
-            Size of the model vocabulary.
     """
 
     auto_model_class = AutoModelForImageClassification
 
-    def __init__(self, model: "ExecuTorchModule", config: "PretrainedConfig"):
-        super().__init__(model, config)
+    def __init__(self, models: Dict[str, "ExecuTorchModule"], config: "PretrainedConfig"):
+        super().__init__(models, config)
+        if not hasattr(self, "model"):
+            raise AttributeError("Expected attribute 'model' not found in the instance.")
         metadata = self.model.method_names()
         logging.debug(f"Load all static methods: {metadata}")
 
@@ -1175,220 +866,8 @@ class ExecuTorchModelForImageClassification(OptimizedModel):
         Returns:
             torch.Tensor: Logits output from the model.
         """
+        # Reset stats for a new generation
         return self.model.forward((pixel_values,))[0]
 
-    @classmethod
-    def _from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        config: PretrainedConfig,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        file_name: Optional[str] = None,
-        **kwargs,
-    ) -> "ExecuTorchModelForImageClassification":
-        if isinstance(model_id, Path):
-            model_id = model_id.as_posix()
-
-        default_file_name = file_name or "model.pte"
-
-        pte_files = find_files_matching_pattern(
-            model_id,
-            _FILE_PATTERN,
-            glob_pattern="**/*.pte",
-            subfolder=subfolder,
-            token=token,
-            revision=revision,
-        )
-
-        if len(pte_files) == 0:
-            raise FileNotFoundError(f"Could not find any ExecuTorch model file in {model_id}")
-        if len(pte_files) == 1 and file_name and file_name != pte_files[0].name:
-            raise FileNotFoundError(f"Trying to load {file_name} but only found {pte_files[0].name}")
-
-        file_name = pte_files[0].name
-        subfolder = pte_files[0].parent
-
-        if len(pte_files) > 1:
-            for file in pte_files:
-                if file.name == default_file_name:
-                    file_name = file.name
-                    subfolder = file.parent
-                    break
-
-            logger.warning(
-                f"Too many ExecuTorch model files were found in {' ,'.join(map(str, pte_files))}. "
-                "specify which one to load by using the `file_name` and/or the `subfolder` arguments. "
-                f"Loading the file {file_name} in the subfolder {subfolder}."
-            )
-
-        if os.path.isdir(model_id):
-            model_id = subfolder
-            subfolder = ""
-
-        model_cache_path = cls._cached_file(
-            model_path=model_id,
-            token=token,
-            revision=revision,
-            force_download=force_download,
-            cache_dir=cache_dir,
-            file_name=default_file_name,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-        )
-        model = _load_for_executorch(model_cache_path)
-        logging.info(f"Loaded model from {model_cache_path}")
-
-        return cls(model, config=config)
-
-    @staticmethod
-    def _cached_file(
-        model_path: Union[Path, str],
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        force_download: bool = False,
-        cache_dir: Optional[str] = None,
-        file_name: Optional[str] = None,
-        subfolder: str = "",
-        local_files_only: bool = False,
-    ):
-        model_path = Path(model_path)
-        # locates a file in a local folder and repo, downloads and cache it if necessary.
-        if model_path.is_dir():
-            model_cache_path = os.path.join(model_path, subfolder, file_name)
-        else:
-            model_cache_path = hf_hub_download(
-                repo_id=model_path.as_posix(),
-                filename=file_name,
-                subfolder=subfolder,
-                token=token,
-                revision=revision,
-                cache_dir=cache_dir,
-                force_download=force_download,
-                local_files_only=local_files_only,
-            )
-
-        return model_cache_path
-
-    @classmethod
-    def _export(
-        cls,
-        model_id: str,
-        recipe: str,
-        config: PretrainedConfig,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        trust_remote_code: bool = False,
-        subfolder: str = "",
-        force_download: bool = False,
-        local_files_only: bool = False,
-        **kwargs,
-    ):
-        save_dir = TemporaryDirectory()
-        save_dir_path = Path(save_dir.name)
-
-        # Export to ExecuTorch and save the pte file to the temporary directory
-        main_export(
-            model_name_or_path=model_id,
-            output_dir=save_dir_path,
-            task="image-classification",
-            recipe=recipe,
-            subfolder=subfolder,
-            revision=revision,
-            cache_dir=cache_dir,
-            token=token,
-            local_files_only=local_files_only,
-            force_download=force_download,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )
-        return cls._from_pretrained(model_id=save_dir_path, config=config)
-
-    def _save_pretrained(self, save_directory):
-        """
-        Saves a model weights into a directory, so that it can be re-loaded using the
-        [`from_pretrained`] class method.
-        """
+    def generate(self):
         raise NotImplementedError
-
-    @classmethod
-    @add_start_docstrings(FROM_PRETRAINED_START_DOCSTRING)
-    def from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        export: bool = False,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
-        subfolder: str = "",
-        trust_remote_code: bool = False,
-        force_download: bool = False,
-        local_files_only: bool = False,
-        cache_dir: str = HUGGINGFACE_HUB_CACHE,
-        config: Optional[PretrainedConfig] = None,
-        **kwargs,
-    ):
-        if isinstance(model_id, Path):
-            model_id = model_id.as_posix()
-
-        if is_offline_mode() and not local_files_only:
-            logger.info("Offline mode: setting `local_files_only=True`")
-            local_files_only = True
-
-        _export = export
-        try:
-            if local_files_only and not os.path.isdir(model_id):
-                object_id = model_id.replace("/", "--")
-                cached_model_dir = os.path.join(cache_dir, f"models--{object_id}")
-                refs_file = os.path.join(os.path.join(cached_model_dir, "refs"), revision or "main")
-                with open(refs_file) as f:
-                    _revision = f.read()
-                model_dir = os.path.join(cached_model_dir, "snapshots", _revision)
-            else:
-                model_dir = model_id
-
-            pte_files = find_files_matching_pattern(
-                model_dir,
-                pattern=_FILE_PATTERN,
-                glob_pattern="**/*.pte",
-                subfolder=subfolder,
-                token=token,
-                revision=revision,
-            )
-
-            _export = len(pte_files) == 0
-            if _export ^ export:
-                if export:
-                    logger.warning(
-                        f"The model {model_id} was already converted to the ExecuTorch IR but got `export=True`, the model will be converted to ExecuTorch once again. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
-                    )
-                    _export = True
-                else:
-                    logger.warning(
-                        f"No ExecuTorch files were found for {model_id}, setting `export=True` to convert the model to the ExecuTorch IR. "
-                        # "Don't forget to save the resulting model with `.save_pretrained()`"
-                    )
-        except Exception as exception:
-            logger.warning(
-                f"Could not infer whether the model was already converted or not to the ExecuTorch IR, keeping `export={export}`.\n{exception}"
-            )
-
-        from_pretrained_method = cls._export if _export else cls._from_pretrained
-
-        return from_pretrained_method(
-            model_id=model_id,
-            config=config,
-            revision=revision,
-            cache_dir=cache_dir,
-            force_download=force_download,
-            token=token,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )

--- a/optimum/executorch/stats.py
+++ b/optimum/executorch/stats.py
@@ -1,0 +1,200 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import time
+from typing import Dict
+
+
+class Stats:
+    """Python equivalent of the ExecuTorch C++ Stats structure for measuring LLM execution latency.
+
+    This class provides methods to track various timestamps during model execution,
+    including model loading, inference, token generation, and sampling times.
+    """
+
+    def __init__(self):
+        # Scaling factor for timestamps - in ms
+        self.SCALING_FACTOR_UNITS_PER_SECOND = 1000
+
+        # Time stamps for different execution stages
+        self.model_load_start_ms = 0
+        self.model_load_end_ms = 0
+        self.inference_start_ms = 0
+        self.token_encode_end_ms = 0
+        self.model_execution_start_ms = 0
+        self.model_execution_end_ms = 0
+        self.prompt_eval_end_ms = 0
+        self.first_token_ms = 0
+        self.inference_end_ms = 0
+
+        # Sampling time tracking
+        self.aggregate_sampling_time_ms = 0
+        self._aggregate_sampling_timer_start_timestamp = 0
+
+        # Token counts
+        self.num_prompt_tokens = 0
+        self.num_generated_tokens = 0
+
+    def on_model_load_start(self):
+        """Mark the start of model loading."""
+        self.model_load_start_ms = self._time_in_ms()
+
+    def on_model_load_end(self):
+        """Mark the end of model loading."""
+        self.model_load_end_ms = self._time_in_ms()
+
+    def on_inference_start(self):
+        """Mark the start of inference (includes tokenizer encode time)."""
+        self.inference_start_ms = self._time_in_ms()
+
+    def on_token_encode_end(self):
+        """Mark the end of token encoding."""
+        self.token_encode_end_ms = self._time_in_ms()
+
+    def on_model_execution_start(self):
+        """Mark the start of the model's forward execution."""
+        self.model_execution_start_ms = self._time_in_ms()
+
+    def on_model_execution_end(self):
+        """Mark the end of the model's forward execution."""
+        self.model_execution_end_ms = self._time_in_ms()
+
+    def on_prompt_eval_end(self):
+        """Mark the end of prompt evaluation."""
+        self.prompt_eval_end_ms = self._time_in_ms()
+
+    def on_first_token(self):
+        """Mark when the first generated token is emitted."""
+        self.first_token_ms = self._time_in_ms()
+
+    def on_inference_end(self):
+        """Mark the end of inference/generation."""
+        self.inference_end_ms = self._time_in_ms()
+
+    def on_sampling_begin(self):
+        """Mark the start of sampling."""
+        self._aggregate_sampling_timer_start_timestamp = self._time_in_ms()
+
+    def on_sampling_end(self):
+        """Mark the end of sampling and update the aggregate sampling time."""
+        self.aggregate_sampling_time_ms += self._time_in_ms() - self._aggregate_sampling_timer_start_timestamp
+        self._aggregate_sampling_timer_start_timestamp = 0
+
+    def set_num_prompt_tokens(self, count: int):
+        """Set the number of prompt tokens."""
+        self.num_prompt_tokens = count
+
+    def set_num_generated_tokens(self, count: int):
+        """Set the number of generated tokens."""
+        self.num_generated_tokens = count
+
+    def reset(self, all_stats: bool = False):
+        """Reset stats, optionally including model load times."""
+        if all_stats:
+            self.model_load_start_ms = 0
+            self.model_load_end_ms = 0
+
+        self.inference_start_ms = 0
+        self.token_encode_end_ms = 0
+        self.model_execution_start_ms = 0
+        self.model_execution_end_ms = 0
+        self.prompt_eval_end_ms = 0
+        self.first_token_ms = 0
+        self.inference_end_ms = 0
+        self.aggregate_sampling_time_ms = 0
+        self.num_prompt_tokens = 0
+        self.num_generated_tokens = 0
+        self._aggregate_sampling_timer_start_timestamp = 0
+
+    def to_json(self) -> Dict:
+        """Convert the stats to a JSON-serializable dictionary."""
+        return {
+            "prompt_tokens": self.num_prompt_tokens,
+            "generated_tokens": self.num_generated_tokens,
+            "model_load_start_ms": self.model_load_start_ms,
+            "model_load_end_ms": self.model_load_end_ms,
+            "inference_start_ms": self.inference_start_ms,
+            "token_encode_end_ms": self.token_encode_end_ms,
+            "model_execution_start_ms": self.model_execution_start_ms,
+            "model_execution_end_ms": self.model_execution_end_ms,
+            "inference_end_ms": self.inference_end_ms,
+            "prompt_eval_end_ms": self.prompt_eval_end_ms,
+            "first_token_ms": self.first_token_ms,
+            "aggregate_sampling_time_ms": self.aggregate_sampling_time_ms,
+            "SCALING_FACTOR_UNITS_PER_SECOND": self.SCALING_FACTOR_UNITS_PER_SECOND,
+        }
+
+    def to_json_string(self) -> str:
+        """Convert the stats to a JSON string."""
+        return json.dumps(self.to_json())
+
+    def print_report(self):
+        """Print a report of the stats, similar to the C++ implementation."""
+        print(f"PyTorchObserver {self.to_json_string()}")
+
+        print(f"\tPrompt Tokens: {self.num_prompt_tokens} Generated Tokens: {self.num_generated_tokens}")
+
+        model_load_time = (self.model_load_end_ms - self.model_load_start_ms) / self.SCALING_FACTOR_UNITS_PER_SECOND
+        print(f"\tModel Load Time:\t\t{model_load_time:.6f} (seconds)")
+
+        inference_time_ms = self.inference_end_ms - self.inference_start_ms
+        inference_time = inference_time_ms / self.SCALING_FACTOR_UNITS_PER_SECOND
+
+        if inference_time_ms > 0 and self.num_generated_tokens > 0:
+            inference_rate = (self.num_generated_tokens / inference_time_ms) * self.SCALING_FACTOR_UNITS_PER_SECOND
+        else:
+            inference_rate = 0
+
+        print(
+            f"\tTotal inference time:\t\t{inference_time:.6f} (seconds)\t\t Rate: \t{inference_rate:.6f} (tokens/second)"
+        )
+
+        prompt_eval_time = (self.prompt_eval_end_ms - self.inference_start_ms) / self.SCALING_FACTOR_UNITS_PER_SECOND
+
+        if (self.prompt_eval_end_ms - self.inference_start_ms) > 0 and self.num_prompt_tokens > 0:
+            prompt_eval_rate = (
+                self.num_prompt_tokens / (self.prompt_eval_end_ms - self.inference_start_ms)
+            ) * self.SCALING_FACTOR_UNITS_PER_SECOND
+        else:
+            prompt_eval_rate = 0
+
+        print(
+            f"\t\tPrompt evaluation:\t{prompt_eval_time:.6f} (seconds)\t\t Rate: \t{prompt_eval_rate:.6f} (tokens/second)"
+        )
+
+        eval_time = (self.inference_end_ms - self.prompt_eval_end_ms) / self.SCALING_FACTOR_UNITS_PER_SECOND
+
+        if (self.inference_end_ms - self.prompt_eval_end_ms) > 0 and self.num_generated_tokens > 0:
+            eval_rate = (
+                self.num_generated_tokens / (self.inference_end_ms - self.prompt_eval_end_ms)
+            ) * self.SCALING_FACTOR_UNITS_PER_SECOND
+        else:
+            eval_rate = 0
+
+        print(
+            f"\t\tGenerated {self.num_generated_tokens} tokens:\t{eval_time:.6f} (seconds)\t\t Rate: \t{eval_rate:.6f} (tokens/second)"
+        )
+
+        time_to_first_token = (self.first_token_ms - self.inference_start_ms) / self.SCALING_FACTOR_UNITS_PER_SECOND
+        print(f"\tTime to first generated token:\t{time_to_first_token:.6f} (seconds)")
+
+        sampling_time = self.aggregate_sampling_time_ms / self.SCALING_FACTOR_UNITS_PER_SECOND
+        print(
+            f"\tSampling time over {self.num_prompt_tokens + self.num_generated_tokens} tokens:\t{sampling_time:.6f} (seconds)"
+        )
+
+    def _time_in_ms(self) -> int:
+        """Get the current time in milliseconds."""
+        return int(time.time() * 1000)

--- a/tests/models/test_modeling_common.py
+++ b/tests/models/test_modeling_common.py
@@ -45,6 +45,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertTrue(hasattr(model, "model"))
         self.assertIsInstance(model.model, ExecuTorchModule)
 
     def test_load_et_model_from_hub(self):
@@ -52,10 +53,12 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         model = ExecuTorchModelForCausalLM.from_pretrained(model_id, revision="executorch")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertTrue(hasattr(model, "model"))
         self.assertIsInstance(model.model, ExecuTorchModule)
 
         model = ExecuTorchModelForCausalLM.from_pretrained(model_id, revision="executorch-subfolder")
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertTrue(hasattr(model, "model"))
         self.assertIsInstance(model.model, ExecuTorchModule)
 
     def test_load_cached_model_from_local_path(self):
@@ -75,6 +78,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             # Load the exported model from a local dir
             model = ExecuTorchModelForCausalLM.from_pretrained(tempdir)
             self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+            self.assertTrue(hasattr(model, "model"))
             self.assertIsInstance(model.model, ExecuTorchModule)
 
     def test_find_files_matching_pattern(self):

--- a/tests/models/test_modeling_efficientnet.py
+++ b/tests/models/test_modeling_efficientnet.py
@@ -1,0 +1,78 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import pytest
+import torch
+from executorch import version
+from executorch.extension.pybindings.portable_lib import ExecuTorchModule
+from transformers import AutoConfig, AutoModelForImageClassification
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForImageClassification
+
+from ..utils import check_close_recursively
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_efficientnet_export_to_executorch(self):
+        model_id = "google/efficientnet-b7"  # ~66M params
+        task = "image-classification"
+        recipe = "xnnpack"
+        with tempfile.TemporaryDirectory() as tempdir:
+            subprocess.run(
+                f"optimum-cli export executorch --model {model_id} --task {task} --recipe {recipe} --output_dir {tempdir}/executorch",
+                shell=True,
+                check=True,
+            )
+            self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.skipif(
+        version.__version__ < "0.6.0",
+        reason="The fix in XNNPACK is cherry-picked in 0.6.0 release",
+    )
+    def test_efficientnet_image_classification(self):
+        model_id = "google/efficientnet-b0"  # ~5.3M params
+
+        config = AutoConfig.from_pretrained(model_id)
+        batch_size = 1
+        num_channels = config.num_channels
+        height = config.image_size
+        width = config.image_size
+        pixel_values = torch.rand(batch_size, num_channels, height, width)
+
+        # Test fetching and lowering the model to ExecuTorch
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
+        self.assertIsInstance(et_model.model, ExecuTorchModule)
+
+        eager_model = AutoModelForImageClassification.from_pretrained(model_id).eval().to("cpu")
+        with torch.no_grad():
+            eager_output = eager_model(pixel_values)
+            et_output = et_model.forward(pixel_values)
+
+        # Compare with eager outputs
+        self.assertTrue(check_close_recursively(eager_output.logits, et_output))

--- a/tests/models/test_modeling_t5.py
+++ b/tests/models/test_modeling_t5.py
@@ -54,8 +54,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         model = ExecuTorchModelForSeq2SeqLM.from_pretrained(model_id, recipe="xnnpack")
 
         self.assertIsInstance(model, ExecuTorchModelForSeq2SeqLM)
-        self.assertIsInstance(model.et_encoder, ExecuTorchModule)
-        self.assertIsInstance(model.et_decoder, ExecuTorchModule)
+        self.assertTrue(hasattr(model, "encoder"))
+        self.assertIsInstance(model.encoder, ExecuTorchModule)
+        self.assertTrue(hasattr(model, "decoder"))
+        self.assertIsInstance(model.decoder, ExecuTorchModule)
 
         input_text = "translate English to German: How old are you?"
         generated_text = model.text_generation(
@@ -74,8 +76,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         model = ExecuTorchModelForSeq2SeqLM.from_pretrained(model_id, recipe="xnnpack")
 
         self.assertIsInstance(model, ExecuTorchModelForSeq2SeqLM)
-        self.assertIsInstance(model.et_encoder, ExecuTorchModule)
-        self.assertIsInstance(model.et_decoder, ExecuTorchModule)
+        self.assertTrue(hasattr(model, "encoder"))
+        self.assertIsInstance(model.encoder, ExecuTorchModule)
+        self.assertTrue(hasattr(model, "decoder"))
+        self.assertIsInstance(model.decoder, ExecuTorchModule)
 
         article = (
             " New York (CNN)When Liana Barrientos was 23 years old, she got married in Westchester County, New York. A"


### PR DESCRIPTION
1. Add latency measurement for text models
  - Bring the ExecuTorch c++ runner measurements ([`stats.h`](https://github.com/pytorch/executorch/blob/main/extension/llm/runner/stats.h)) to `optimum-executorch` in python. Eventually we could remove the py impl and utilize it from extensions/llm via pybind.
  - Measure the latency of `ExecuTorchModelForSeq2SeqLM` and `ExecuTorchModelForCausalLM`

2. `modeling.py` refactor to reduce duplicate code:
 - Create a `ExecuTorchModelBase` that represent the ExecuTorch inference model, with implementation of export, load from cache/hub, etc. common methods. Defined abstract method `forward`, `generate`, etc. that each derived concrete class must implement
 - Making all supported ExecuTorch inference classes (`ExecuTorchModelForSeq2SeqLM`, `ExecuTorchModelForCausalLM`, etc.) lightweight and easy to scale

3. Added `efficientnet` model. Conditionally run only when executorch >= 0.6 (so it will run on the pinned nightly). Previously broken due to a bug a in XNNPACK, which has been fixed and picked to the upcoming `executorch 0.6` release.