### PR TITLE
Bump Transformers verion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "optimum~=1.24",
     "executorch>=0.4.0,!=0.5.0",  # https://github.com/huggingface/optimum-executorch/issues/14
-    "transformers>=4.46,<=4.50.1",
+    "transformers==4.51.0",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
Have to bump to latest version of Transformers in order to use `AttentionInterface`. It seems like there are breaking changes in `4.50.1`, `4.50.2`, `4.50.3` causing errors when import `AttentionInterface` via `from transformers.modeling_utils import AttentionInterface`