### PR TITLE
Support ExecuTorch 0.6.0

### DIFF
--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         test-modeling: ${{ fromJson(needs.discover-tests.outputs.model_names) }}
-        executorch-version: ['0.4.0', '0.6.0rc', 'nightly']
+        executorch-version: ['0.6.0', 'nightly']
         python-version: ['3.11']
         os: [macos-15, ubuntu-22.04]
 
@@ -58,8 +58,6 @@ jobs:
               torchvision==0.22.0.${NIGHTLY_VERSION} \
               torchaudio==2.6.0.${NIGHTLY_VERSION} \
               --extra-index-url "https://download.pytorch.org/whl/nightly/cpu"
-          elif [ "${{ matrix.executorch-version }}" == "0.6.0rc" ]; then
-            pip install --pre executorch==0.6.0 torch==2.7.0 torchvision torchaudio --extra-index-url "https://download.pytorch.org/whl/test/cpu"
           else
             pip install executorch==${{ matrix.executorch-version }}
           fi

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except Exception as error:
 
 INSTALL_REQUIRE = [
     "optimum~=1.24",
-    "executorch>=0.4.0,!=0.5.0",  # https://github.com/huggingface/optimum-executorch/issues/14
+    "executorch>=0.6.0",
     "transformers==4.51.0",
 ]
 


### PR DESCRIPTION
**THIS PR IS A PLACEHOLDER AND SHOULD NOT BE MERGED UNTIL 4/24/2025, AFTER THE `executorch 0.6.0` IS GENERAL AVAILABLE.**

This PR:
- bump up the min supported version of `executorch`
- install official package instead of RC

cc: @mergennachin @metascroy