### PR TITLE
Add support for sliding window via ring kv cache

### DIFF
--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250620"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250625"
     TORCHAO_NIGHTLY_VERSION = "dev20250620"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250601"
@@ -34,7 +34,7 @@ def install_dep_from_source():
             "-m",
             "pip",
             "install",
-            "git+https://github.com/huggingface/transformers@51f94ea06d19a6308c61bbb4dc97c40aabd12bad#egg=transformers",  # v4.52.4
+            "git+https://github.com/huggingface/transformers@37367c7d9fd23401c26e79a2b26253ab2d1b7236#egg=transformers",
         ]
     )
     subprocess.check_call(

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -21,9 +21,19 @@ except ImportError:
 try:
     from executorch.examples.models.llama.source_transformation.custom_kv_cache import (
         CustomKVCache,
+        CustomRingKVCache,
     )
 except ImportError:
     raise ImportError("ExecutorTorch is not installed. Please install it to use CustomKVCache.")
+
+try:
+    from transformers.cache_utils import HybridCache
+except ImportError:
+    # If transformers is not installed, raise an ImportError
+    try:
+        from transformers.cache_utils import HybridCache
+    except ImportError:
+        raise ImportError("transformers is not installed. Please install it to use HybridCache.")
 
 
 class ETCustomStaticCache(StaticCache):
@@ -55,7 +65,7 @@ class ETCustomStaticCache(StaticCache):
         assert device is None or device == "cpu", "Device must be None or 'cpu'"
 
         # Create a list of CustomKVCache instances, one per layer
-        kv_cache_list = []
+        self.kv_cache = torch.nn.ModuleList()
         for _ in range(config.num_hidden_layers):
             layer_cache = CustomKVCache(
                 max_batch_size=self.max_batch_size,
@@ -64,8 +74,7 @@ class ETCustomStaticCache(StaticCache):
                 head_dim=self.head_dim,
                 dtype=dtype,
             )
-            kv_cache_list.append(layer_cache)
-        self.kv_cache = torch.nn.ModuleList(kv_cache_list)
+            self.kv_cache.append(layer_cache)
 
     def update(
         self,
@@ -180,6 +189,135 @@ class ETCustomStaticCache(StaticCache):
         )
 
 
+# Need to figure out if I have to inherit from HybridCache or StaticCache
+class ETCustomHybridCache(HybridCache):
+    """
+    Custom Hybrid KV Cache implementation for ExecutorTorch that inherits from Hugging Face's HybridCache
+    but uses ExecutorTorch's CustomKVCache for global layers and CustomRingKVCache for sliding window layers.
+    """
+
+    def __init__(
+        self,
+        config,
+        max_batch_size: int,
+        max_cache_len: Optional[int] = None,
+        device: Union[torch.device, str, None] = None,
+        dtype: torch.dtype = torch.float32,
+        layer_device_map: Optional[Dict[int, Union[str, torch.device, int]]] = None,
+    ):
+        super().__init__(
+            config=config,
+            max_batch_size=max_batch_size,
+            max_cache_len=max_cache_len,
+            device=device,
+            dtype=dtype,
+            layer_device_map=layer_device_map,
+        )
+
+        # make sure layer_device_map is none
+        assert layer_device_map is None
+        assert device is None or device == "cpu", "Device must be None or 'cpu'"
+
+        self.cache_position = None
+        # Create a list of cache instances, one per layer
+        # Use CustomKVCache for global layers and CustomRingKVCache for sliding window layers
+        self.kv_cache = torch.nn.ModuleList()
+        for layer_idx in range(config.num_hidden_layers):
+            # newer version of transfomer has is_sliding defined
+            # for HybridCache
+            if self.is_sliding_list[layer_idx]:
+                # This is a sliding window layer
+                layer_cache = CustomRingKVCache(
+                    max_batch_size=self.max_batch_size,
+                    max_context_length=self.sliding_window_len,
+                    n_heads=self.num_key_value_heads,
+                    head_dim=self.head_dim,
+                    dtype=dtype,
+                )
+            else:
+                layer_cache = CustomKVCache(
+                    max_batch_size=self.max_batch_size,
+                    max_context_length=self.max_cache_len,
+                    n_heads=self.num_key_value_heads,
+                    head_dim=self.head_dim,
+                    dtype=dtype,
+                )
+            self.kv_cache.append(layer_cache)
+
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        cache_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Updates the cache with the new `key_states` and `value_states` for the layer `layer_idx`
+        using ExecutorTorch's CustomKVCache or CustomRingKVCache depending on the layer type.
+
+        Args:
+            key_states (`torch.Tensor`):
+                The new key states to cache. Shape: [batch_size, n_heads, seq_len, head_dim]
+            value_states (`torch.Tensor`):
+                The new value states to cache. Shape: [batch_size, n_heads, seq_len, head_dim]
+            layer_idx (`int`):
+                The index of the layer to cache the states for.
+            cache_kwargs (`Dict[str, Any]`, `optional`):
+                Additional arguments for the cache update.
+
+        Returns:
+            A tuple containing the updated key and value states.
+        """
+        assert cache_kwargs is not None
+
+        # Get cache position from cache_kwargs (used by HybridCache)
+        cache_position = cache_kwargs.get("cache_position")
+        assert cache_position is not None
+        assert isinstance(cache_position, torch.Tensor)
+        self.cache_position = cache_position
+
+        # Get the cache instance for this layer (either CustomKVCache or CustomRingKVCache)
+        layer_cache = self.kv_cache[layer_idx]
+
+        # Use the cache's update method
+        # Both CustomKVCache and CustomRingKVCache have the same update interface
+        k_out, v_out = layer_cache.update(
+            input_pos=cache_position,
+            k_val=key_states,
+            v_val=value_states,
+        )
+
+        return k_out, v_out
+
+    def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
+        """Returns the sequence length of the cached states. A layer index can be optionally passed."""
+        if layer_idx is None:
+            layer_idx = 0
+
+        # For CustomRingKVCache, we need to handle the sequence length differently
+        layer_cache = self.kv_cache[layer_idx]
+        if self.is_sliding[layer_idx]:
+            # CustomRingKVCache cache_position_manager which
+            # maintains cache position for each slot in the kv cache
+            # we return the max position + 1 to indicate max position
+            # seen so far. Not sure if thats the correct interpretation
+            # of sequence length
+            return layer_cache.cache_positions_manager.cache_positions.max().item() + 1
+        return (layer_cache.k_cache[0, :, 0].any(dim=-1)).sum()
+
+    def get_layer_cache(self, layer_idx: int):
+        """
+        Get the cache for a specific layer. This method is dynamo-traceable.
+
+        Args:
+            layer_idx (int): The layer index
+
+        Returns:
+            The cache instance for the specified layer (CustomKVCache or CustomRingKVCache)
+        """
+        return self.kv_cache[layer_idx]
+
+
 def replace_with_et_custom_kv_cache(module, config, generation_config, cache_dtype):
     """
     Replace all KV caches in the module with ETCustomStaticCache.
@@ -192,22 +330,6 @@ def replace_with_et_custom_kv_cache(module, config, generation_config, cache_dty
     Returns:
         The modified module
     """
-    # Ensure custom ops are registered
-    try:
-        op = torch.ops.llama.update_cache
-        assert op is not None
-    except Exception:
-        try:
-            from executorch.extension.llm.custom_ops import custom_ops  # noqa: F401
-
-            op = torch.ops.llama.update_cache
-            assert op is not None
-        except ImportError:
-            raise ImportError(
-                "ExecutorTorch custom operations are not available. "
-                "Please install executorch with custom operations support."
-            )
-
     # Recursively replace KV caches
     return _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dtype)
 
@@ -223,33 +345,73 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
     Returns:
         The modified module
     """
-    assert hasattr(module, "static_cache")
-    assert isinstance(
-        module.static_cache, StaticCache
-    ), "Only StaticCache transform is supported. Hybrid cache with local global attention is not yet supported"
-    # TODO: Add replace_cache to exported module
-    # in transformer's executorch.py
-    if getattr(module, "replace_cache", None) is not None:
-        static_cache = ETCustomStaticCache(
-            config=config,
-            max_batch_size=generation_config.cache_config.batch_size,
-            max_cache_len=generation_config.cache_config.max_cache_len,
-            device=generation_config.cache_config.device,
-            dtype=cache_dtype,
-        )
-        module.replace_cache(static_cache)
+    # Check if module has static_cache (TorchExportableModuleWithStaticCache)
+    if hasattr(module, "static_cache"):
+        assert isinstance(module.static_cache, StaticCache), f"Expected StaticCache, got {type(module.static_cache)}"
+
+        # TODO: Add replace_cache to exported module
+        # in transformer's executorch.py
+        if getattr(module, "replace_cache", None) is not None:
+            static_cache = ETCustomStaticCache(
+                config=config,
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
+                dtype=cache_dtype,
+            )
+            module.replace_cache(static_cache)
+        else:
+            module.static_cache = ETCustomStaticCache(
+                config=config,
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
+                dtype=cache_dtype,
+            )
+            # Dont know why we need to this even though
+            # CustomKVCache registers the attributes
+            for i in range(len(module.static_cache.kv_cache)):
+                setattr(module, f"key_cache_{i}", module.static_cache.kv_cache[i].k_cache)
+                setattr(module, f"value_cache_{i}", module.static_cache.kv_cache[i].v_cache)
+
+    # Check if module has cache (TorchExportableModuleWithHybridCache)
+    elif hasattr(module, "cache"):
+        assert isinstance(module.cache, HybridCache), f"Expected HybridCache, got {type(module.cache)}"
+
+        # Replace with ETCustomHybridCache
+        if getattr(module, "replace_cache", None) is not None:
+            hybrid_cache = ETCustomHybridCache(
+                config=config,
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
+                dtype=cache_dtype,
+            )
+            module.replace_cache(hybrid_cache)
+        else:
+            module.cache = ETCustomHybridCache(
+                config=config,
+                max_batch_size=generation_config.cache_config.batch_size,
+                max_cache_len=generation_config.cache_config.max_cache_len,
+                device=generation_config.cache_config.device,
+                dtype=cache_dtype,
+            )
+            # Register cache attributes for each layer
+            for i in range(len(module.cache.kv_cache)):
+                setattr(module, f"key_cache_{i}", module.cache.kv_cache[i].k_cache)
+                setattr(module, f"value_cache_{i}", module.cache.kv_cache[i].v_cache)
+                if module.cache.is_sliding_list[i]:
+                    # Register cache_positions as buffer for sliding window layers
+                    # This prevents it from being traced as a constant
+                    module.register_buffer(
+                        f"cache_positions_{i}",
+                        module.cache.kv_cache[i].cache_positions_manager.cache_positions,
+                        persistent=False,
+                    )
     else:
-        module.static_cache = ETCustomStaticCache(
-            config=config,
-            max_batch_size=generation_config.cache_config.batch_size,
-            max_cache_len=generation_config.cache_config.max_cache_len,
-            device=generation_config.cache_config.device,
-            dtype=cache_dtype,
+        raise ValueError(
+            "Module must have either 'static_cache' (TorchExportableModuleWithStaticCache) "
+            "or 'cache' (TorchExportableModuleWithHybridCache) attribute"
         )
-        # Dont know why we need to this even though
-        # CustomKVCache registers the attributes
-        for i in range(len(module.static_cache.kv_cache)):
-            setattr(module, f"key_cache_{i}", module.static_cache.kv_cache[i].k_cache)
-            setattr(module, f"value_cache_{i}", module.static_cache.kv_cache[i].v_cache)
 
     return module

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -9,14 +9,11 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 
 
+# If transformers is not installed, raise an ImportError
 try:
-    from transformers.cache_utils import StaticCache
+    from transformers.cache_utils import HybridCache, StaticCache
 except ImportError:
-    # If transformers is not installed, raise an ImportError
-    try:
-        from transformers.cache_utils import StaticCache
-    except ImportError:
-        raise ImportError("transformers is not installed. Please install it to use StaticCache.")
+    raise ImportError("transformers is not installed. Please install it to use Static/HybridCache.")
 
 try:
     from executorch.examples.models.llama.source_transformation.custom_kv_cache import (
@@ -24,16 +21,7 @@ try:
         CustomRingKVCache,
     )
 except ImportError:
-    raise ImportError("ExecutorTorch is not installed. Please install it to use CustomKVCache.")
-
-try:
-    from transformers.cache_utils import HybridCache
-except ImportError:
-    # If transformers is not installed, raise an ImportError
-    try:
-        from transformers.cache_utils import HybridCache
-    except ImportError:
-        raise ImportError("transformers is not installed. Please install it to use HybridCache.")
+    raise ImportError("ExecutorTorch is not installed. Please install it to use Custom Cache.")
 
 
 class ETCustomStaticCache(StaticCache):

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -213,7 +213,7 @@ class ETCustomHybridCache(HybridCache):
         for layer_idx in range(config.num_hidden_layers):
             # newer version of transfomer has is_sliding defined
             # for HybridCache
-            if self.is_sliding_list[layer_idx]:
+            if self.is_sliding[layer_idx]:
                 # This is a sliding window layer
                 layer_cache = CustomRingKVCache(
                     max_batch_size=self.max_batch_size,
@@ -388,7 +388,7 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
             for i in range(len(module.cache.kv_cache)):
                 setattr(module, f"key_cache_{i}", module.cache.kv_cache[i].k_cache)
                 setattr(module, f"value_cache_{i}", module.cache.kv_cache[i].v_cache)
-                if module.cache.is_sliding_list[i]:
+                if module.cache.is_sliding[i]:
                     # Register cache_positions as buffer for sliding window layers
                     # This prevents it from being traced as a constant
                     module.register_buffer(

--- a/optimum/executorch/attentions/custom_sdpa.py
+++ b/optimum/executorch/attentions/custom_sdpa.py
@@ -12,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 import torch
 from executorch.extension.llm.custom_ops.custom_ops import custom_sdpa  # noqa
+
+from optimum.executorch.attentions.custom_kv_cache import ETCustomHybridCache
+
+
+try:
+    from executorch.examples.models.llama.source_transformation.custom_kv_cache import (
+        CustomRingKVCache,
+    )
+except ImportError:
+    raise ImportError("ExecutorTorch is not installed. Please install it to use CustomRingKVCache.")
 
 
 def custom_sdpa_with_start_pos_forward(
@@ -47,21 +57,84 @@ def custom_sdpa_with_start_pos_forward(
     kwargs.pop("is_causal", None)
     assert module.is_causal, "Current variant supports only causal attention"
 
-    # Calculate the input pos from attention mask.
-    # Branch out for float vs bool mask
-    # assert attention_mask.dim() == 2, f"attention_mask must be a 2D matrix."
-    attention_mask = attention_mask.reshape(-1, max_seq_len)
-    first_row_mask = attention_mask[0, :]
-    # [0, 0, 0, 0, -inf, -inf, -inf, -inf], start_pos = 3
-    start_pos = torch.argmin(first_row_mask.to(torch.long)).item() - 1
+    is_causal = module.is_causal
+    if kwargs.get("is_sliding", False):
+        is_causal = False
+        attn_mask = attention_mask
+        # start_pos is not important when using mask
+        # instead of doing causal attention
+        start_pos = 0
+    else:
+        attn_mask = None
+        # Calculate the input pos from attention mask.
+        # Branch out for float vs bool mask
+        # assert attention_mask.dim() == 2, f"attention_mask must be a 2D matrix."
+        attention_mask = attention_mask.reshape(-1, max_seq_len)
+        first_row_mask = attention_mask[0, :]
+        # [0, 0, 0, 0, -inf, -inf, -inf, -inf], start_pos = 3
+        start_pos = torch.argmin(first_row_mask.to(torch.long)).item() - 1
+
     output = torch.ops.llama.custom_sdpa(
         query,
         key,
         value,
         start_pos=start_pos,
-        attn_mask=None,
+        attn_mask=attn_mask,
         drpout_p=0.0,
-        is_causal=module.is_causal,
+        is_causal=is_causal,
         scale=scaling,
     )
     return output.to(input_dtype), None
+
+
+def get_custom_sdpa_for_ring_kv_cache(
+    exportable_module: torch.nn.Module,
+) -> Callable:
+    def _custom_sdpa_for_ring_kv_cache(
+        module: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attention_mask: Union[torch.Tensor, "BlockMask"],  # noqa
+        scaling: Optional[float] = None,
+        softcap: Optional[float] = None,
+        head_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, None]:
+        is_sliding = getattr(module, "is_sliding", False)
+        if is_sliding:
+            layer_idx = module.layer_idx
+            assert layer_idx is not None, "layer_idx is not set for sliding window attention."
+            hybrid_cache = exportable_module.model.cache
+            assert isinstance(hybrid_cache, ETCustomHybridCache), f"Expected HybridCache, got {type(hybrid_cache)}"
+            ring_cache = hybrid_cache.get_layer_cache(layer_idx)
+            assert isinstance(ring_cache, CustomRingKVCache), f"Expected CustomRingKVCache, got {type(ring_cache)}"
+            input_pos = hybrid_cache.cache_position[0].item()
+            seqlen = query.shape[2]
+            attention_mask = ring_cache.create_causal_mask_for_ring_buffer(input_pos, seqlen)
+            kwargs.update({"is_sliding": True})
+            return custom_sdpa_with_start_pos_forward(
+                module,
+                query,
+                key,
+                value,
+                attention_mask,
+                scaling,
+                softcap,
+                head_mask,
+                **kwargs,
+            )
+        else:
+            return custom_sdpa_with_start_pos_forward(
+                module,
+                query,
+                key,
+                value,
+                attention_mask,
+                scaling,
+                softcap,
+                head_mask,
+                **kwargs,
+            )
+
+    return _custom_sdpa_for_ring_kv_cache

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -38,12 +38,32 @@ class CausalLMExportableModule(torch.nn.Module):
     This module ensures that the exported model is compatible with ExecuTorch.
     """
 
-    def __init__(self, model, use_custom_kv_cache=False):
+    def __init__(self, model, use_custom_kv_cache=False, use_custom_sdpa=False):
         super().__init__()
         self.model = model
         self.config = model.config
         self.use_custom_kv_cache = use_custom_kv_cache
+        self.use_custom_sdpa = use_custom_sdpa
         self.metadata = save_config_to_constant_methods(model.config, model.generation_config)
+
+    def _register_attention_mask_for_4_53(self, exportable_module: torch.nn.Module):
+        if is_transformers_version(">=", "4.53.0.dev0"):
+            from transformers.integrations.executorch import sdpa_mask_without_vmap
+            from transformers.masking_utils import AttentionMaskInterface
+            from transformers.modeling_utils import AttentionInterface
+
+            _custom_sdpa_for_ring_kv_cache = get_custom_sdpa_for_ring_kv_cache(exportable_module)
+            if self.use_custom_sdpa:
+                if self.use_custom_kv_cache:
+                    AttentionInterface.register("custom_sdpa_ring_kv_cache", _custom_sdpa_for_ring_kv_cache)
+                    AttentionMaskInterface.register("custom_sdpa_ring_kv_cache", sdpa_mask_without_vmap)
+                    # Manually set the attention implementation to custom_sdpa_ring_kv_cache
+                    # This handles both regular sdpa and one for sliding window/local attention
+                    exportable_module.model.model.config._attn_implementation = "custom_sdpa_ring_kv_cache"
+                else:
+                    # Manually set the attention implementation to custom_sdpa_ring_kv_cache
+                    # This handles both regular sdpa and one for sliding window/local attention
+                    exportable_module.model.model.config._attn_implementation = "custom_sdpa"
 
     def export(self, input_ids=None, cache_position=None) -> Dict[str, ExportedProgram]:
         example_input_ids = input_ids if input_ids is not None else torch.tensor([[1]], dtype=torch.long)
@@ -57,12 +77,7 @@ class CausalLMExportableModule(torch.nn.Module):
             max_batch_size = 1
             max_cache_len = 4094
             exportable_module = TorchExportableModuleForDecoderOnlyLM(self.model, max_batch_size, max_cache_len)
-
-            from transformers.modeling_utils import AttentionInterface
-
-            _custom_sdpa_for_ring_kv_cache = get_custom_sdpa_for_ring_kv_cache(exportable_module)
-            AttentionInterface.register("custom_sdpa_ring_kv_cache", _custom_sdpa_for_ring_kv_cache)
-            exportable_module.model.model.config._attn_implementation = "custom_sdpa_ring_kv_cache"
+            self._register_attention_mask_for_4_53(exportable_module)
             if self.use_custom_kv_cache:
                 from optimum.executorch.attentions.custom_kv_cache import (
                     replace_with_et_custom_kv_cache,

--- a/optimum/exporters/executorch/recipes/xnnpack.py
+++ b/optimum/exporters/executorch/recipes/xnnpack.py
@@ -97,7 +97,10 @@ def export_to_executorch_with_xnnpack(
 
     exported_progs = model.export()
 
-    if model.config._attn_implementation == "custom_sdpa":
+    if (
+        model.config._attn_implementation == "custom_sdpa"
+        or model.config._attn_implementation == "custom_sdpa_ring_kv_cache"
+    ):
         # Sanity check to make sure the exported program contains the custom sdpa operator.
         if not any(
             node.op == "call_function" and "custom_sdpa" in str(node.target)

--- a/optimum/exporters/executorch/tasks/causal_lm.py
+++ b/optimum/exporters/executorch/tasks/causal_lm.py
@@ -58,6 +58,7 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
     use_custom_kv_cache = kwargs.get("use_custom_kv_cache", False)
     attn_implementation = kwargs.get("attn_implementation", "custom_sdpa" if use_custom_sdpa else "sdpa")
     cache_implementation = kwargs.get("cache_implementation", "static")
+    use_custom_sdpa = use_custom_sdpa or attn_implementation == "custom_sdpa"
     max_length = kwargs.get("max_length", 2048)
     config = kwargs.get("config", None)
 
@@ -126,4 +127,4 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
 
         unwrap_tensor_subclass(eager_model)
 
-    return CausalLMExportableModule(eager_model, use_custom_kv_cache)
+    return CausalLMExportableModule(eager_model, use_custom_kv_cache, use_custom_sdpa)

--- a/tests/models/test_modeling_gemma3.py
+++ b/tests/models/test_modeling_gemma3.py
@@ -23,11 +23,13 @@ import unittest
 
 import pytest
 import torchao
+import transformers
 from executorch.extension.pybindings.portable_lib import ExecuTorchModule
 from packaging.version import parse
 from transformers import AutoTokenizer
 from transformers.testing_utils import slow
 
+from executorch import version
 from optimum.executorch import ExecuTorchModelForCausalLM
 from optimum.utils.import_utils import is_transformers_version
 
@@ -195,6 +197,44 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             model_id,
             recipe="xnnpack",
             attn_implementation="custom_sdpa",
+            **kwargs,
+        )
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        generated_text = model.text_generation(
+            tokenizer=tokenizer,
+            prompt=prompt,
+            max_seq_len=64,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")
+        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
+
+        # Free memory before loading eager for quality check
+        del model
+        del tokenizer
+        gc.collect()
+
+        self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @pytest.mark.skipif(
+        parse(transformers.__version__) < parse("4.52.0") or parse(torchao.__version__) < parse("0.11.0") or parsee(version.__version__) <= parse("0.6.0"),
+        reason="Only available on transformers >= 4.52.0 and torchao >= 0.11.0 executorch > 0.6.0",
+    )
+    def test_gemma3_text_generation_with_custom_sdpa_kv_cache_8da4w_8we(self):
+        # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI
+        # model_id = "google/gemma-3-1b-it"
+        model_id = "unsloth/gemma-3-1b-it"
+        prompt = "Write a poem about a machine learning."
+
+        # ExecuTorch model + custom sdpa + 8da4w linear quantization + int8 embedding quantization
+        kwargs = {"qlinear": True, "qembedding": True}
+        model = ExecuTorchModelForCausalLM.from_pretrained(
+            model_id,
+            recipe="xnnpack",
+            attn_implementation="custom_sdpa",
+            use_custom_kv_cache=True,
             **kwargs,
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)

--- a/tests/models/test_modeling_gemma3.py
+++ b/tests/models/test_modeling_gemma3.py
@@ -112,6 +112,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
+    @pytest.mark.skipif(
+        parse(transformers.__version__) < parse("4.53.0.dev0") or parse(torchao.__version__) < parse("0.11.0"),
+        reason="Only available on transformers >= 4.53.0.dev0 and torchao >= 0.11.0",
+    )
     def test_gemma3_text_generation_with_custom_sdpa(self):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI
         # model_id = "google/gemma-3-1b-it"
@@ -181,8 +185,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.skipif(
-        parse(torchao.__version__) < parse("0.11.0.dev0"),
-        reason="Only available on torchao >= 0.11.0.dev0",
+        parse(transformers.__version__) < parse("4.53.0.dev0") or parse(torchao.__version__) < parse("0.11.0"),
+        reason="Only available on transformers >= 4.53.0.dev0 and torchao >= 0.11.0",
     )
     def test_gemma3_text_generation_with_custom_sdpa_8da4w_8we(self):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI
@@ -217,9 +221,11 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
 
+    @slow
+    @pytest.mark.run_slow
     @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.52.0") or parse(torchao.__version__) < parse("0.11.0"),
-        reason="Only available on transformers >= 4.52.0 and torchao >= 0.11.0",
+        parse(transformers.__version__) < parse("4.53.0.dev0") or parse(torchao.__version__) < parse("0.11.0"),
+        reason="Only available on transformers >= 4.53.0.dev0 and torchao >= 0.11.0",
     )
     def test_gemma3_text_generation_with_custom_sdpa_kv_cache_8da4w_8we(self):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI

--- a/tests/models/test_modeling_gemma3.py
+++ b/tests/models/test_modeling_gemma3.py
@@ -29,7 +29,6 @@ from packaging.version import parse
 from transformers import AutoTokenizer
 from transformers.testing_utils import slow
 
-from executorch import version
 from optimum.executorch import ExecuTorchModelForCausalLM
 from optimum.utils.import_utils import is_transformers_version
 
@@ -219,8 +218,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
 
     @pytest.mark.skipif(
-        parse(transformers.__version__) < parse("4.52.0") or parse(torchao.__version__) < parse("0.11.0") or parsee(version.__version__) <= parse("0.6.0"),
-        reason="Only available on transformers >= 4.52.0 and torchao >= 0.11.0 executorch > 0.6.0",
+        parse(transformers.__version__) < parse("4.52.0") or parse(torchao.__version__) < parse("0.11.0"),
+        reason="Only available on transformers >= 4.52.0 and torchao >= 0.11.0",
     )
     def test_gemma3_text_generation_with_custom_sdpa_kv_cache_8da4w_8we(self):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI


### PR DESCRIPTION
Summary:
This diffs adds
- Ring kv cache for local attention where ring buffer updates cache with new entries in a ring fashion rather than sliding cache
- Correspondingly we have to update sdpa to accept mask that correspond to the state of ring buffer because slot in ring buffer may correspond to different token positions. Thus we cannot just use causal mask.

Now custom_kv_cache option means we support both global attention and local/global like gemma3

Test Plan:
Test added

Reviewers:

Subscribers:

Tasks:

Tags: