### PR TITLE
Changes to accommodate new transformer changes around attention mask

### DIFF
--- a/optimum/exporters/executorch/convert.py
+++ b/optimum/exporters/executorch/convert.py
@@ -22,11 +22,17 @@ from typing import Union
 from transformers.modeling_utils import AttentionInterface
 
 from optimum.executorch.attentions.custom_sdpa import custom_sdpa_with_start_pos_forward
+from optimum.utils.import_utils import is_transformers_version
 
 from .recipe_registry import discover_recipes, recipe_registry
 
 
 AttentionInterface.register("custom_sdpa", custom_sdpa_with_start_pos_forward)
+if is_transformers_version(">=", "4.53.0.dev0"):
+    from transformers.integrations.executorch import sdpa_mask_without_vmap
+    from transformers.masking_utils import AttentionMaskInterface
+
+    AttentionMaskInterface.register("custom_sdpa", sdpa_mask_without_vmap)
 
 
 def export_to_executorch(


### PR DESCRIPTION
Summary:
Post 4.53 custom attention must have attention mask function registered else mask will not be created.

Test Plan:
CI test on top of 4.53 for custom_sdpa although it requires upstream change in transformers

Reviewers:

Subscribers:

Tasks:

Tags: