### PR TITLE
Add option to skip overriding torch deps

### DIFF
--- a/install_dev.py
+++ b/install_dev.py
@@ -1,3 +1,4 @@
+import argparse
 import subprocess
 import sys
 
@@ -46,11 +47,20 @@ def install_dep_from_source():
 
 def main():
     """Install optimum-executorch in dev mode with nightly dependencies"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip_override_torch",
+        action="store_true",
+        help="Skip installation of nightly executorch and torch dependencies",
+    )
+    args = parser.parse_args()
+
     # Install package with dev extras
     subprocess.check_call([sys.executable, "-m", "pip", "install", ".[dev]"])
 
     # Install nightly dependencies
-    install_torch_nightly_deps()
+    if not args.skip_override_torch:
+        install_torch_nightly_deps()
 
     # Install source dependencies
     install_dep_from_source()


### PR DESCRIPTION
Follow up on https://github.com/pytorch/executorch/pull/11450, we would want to test executorch from source with its pinned deps when running the optimum-executorch models in executorch CI. This PR adds option to skip overriding executorch and its torch-related deps when running the setup script `install_dev.py`.