### PR TITLE
Update pinned executorch nightly

### DIFF
--- a/install_dev.py
+++ b/install_dev.py
@@ -5,18 +5,21 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    NIGHTLY_VERSION = "dev20250620"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250620"
+    TORCHAO_NIGHTLY_VERSION = "dev20250620"
+    # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
+    TORCH_NIGHTLY_VERSION = "dev20250601"
     subprocess.check_call(
         [
             sys.executable,
             "-m",
             "pip",
             "install",
-            f"executorch==0.7.0.{NIGHTLY_VERSION}",
-            f"torch==2.8.0.{NIGHTLY_VERSION}",
-            f"torchvision==0.23.0.{NIGHTLY_VERSION}",
-            f"torchaudio==2.8.0.{NIGHTLY_VERSION}",
-            "torchao==0.12.0.dev20250528",
+            f"executorch==0.7.0.{EXECUTORCH_NIGHTLY_VERSION}",
+            f"torch==2.8.0.{TORCH_NIGHTLY_VERSION}",
+            f"torchvision==0.23.0.{TORCH_NIGHTLY_VERSION}",
+            f"torchaudio==2.8.0.{TORCH_NIGHTLY_VERSION}",
+            f"torchao==0.12.0.{TORCHAO_NIGHTLY_VERSION}",
             "--extra-index-url",
             "https://download.pytorch.org/whl/nightly/cpu",
         ]

--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    NIGHTLY_VERSION = "dev20250523"
+    NIGHTLY_VERSION = "dev20250620"
     subprocess.check_call(
         [
             sys.executable,
@@ -14,8 +14,8 @@ def install_torch_nightly_deps():
             "install",
             f"executorch==0.7.0.{NIGHTLY_VERSION}",
             f"torch==2.8.0.{NIGHTLY_VERSION}",
-            f"torchvision==0.22.0.{NIGHTLY_VERSION}",
-            f"torchaudio==2.6.0.{NIGHTLY_VERSION}",
+            f"torchvision==0.23.0.{NIGHTLY_VERSION}",
+            f"torchaudio==2.8.0.{NIGHTLY_VERSION}",
             "torchao==0.12.0.dev20250528",
             "--extra-index-url",
             "https://download.pytorch.org/whl/nightly/cpu",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "optimum~=1.24",
     "executorch>=0.6.0",
-    "transformers==4.52.4",
+    "transformers==4.51.3",
 ]
 
 TESTS_REQUIRE = [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "optimum~=1.24",
     "executorch>=0.6.0",
-    "transformers==4.51.3",
+    "transformers==4.52.4",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
ExecuTorch nightly is unblocked. We can update the pin to pick up fixes that are required by prefill.
Synced all torch deps to the nightly from same day