### PR TITLE
Add coreml quant recipes

### DIFF
--- a/install_dev.py
+++ b/install_dev.py
@@ -5,7 +5,7 @@ import sys
 
 def install_torch_nightly_deps():
     """Install torch related dependencies from pinned nightly"""
-    EXECUTORCH_NIGHTLY_VERSION = "dev20250620"
+    EXECUTORCH_NIGHTLY_VERSION = "dev20250630"
     TORCHAO_NIGHTLY_VERSION = "dev20250620"
     # Torch nightly is aligned with pinned nightly in https://github.com/pytorch/executorch/blob/main/install_requirements.py#L74
     TORCH_NIGHTLY_VERSION = "dev20250601"

--- a/optimum/exporters/executorch/recipes/coreml.py
+++ b/optimum/exporters/executorch/recipes/coreml.py
@@ -105,7 +105,7 @@ def export_to_executorch_with_coreml(
                 "block_size": 32,
             }
         }
-        if quant_recipe not in valid_quant_recipes:
+        if quant_recipe is not None and quant_recipe not in valid_quant_recipes:
             raise ValueError(f"Invalid quant recipe {quant_recipe}, must be one of {valid_quant_recipes.keys()}")
         op_linear_quantizer_config = valid_quant_recipes.get(quant_recipe, None)
 
@@ -134,7 +134,8 @@ def export_to_executorch_with_coreml(
                 ],
                 compile_config=EdgeCompileConfig(
                     _check_ir_validity=False,
-                    _skip_dim_order=False,
+                    # In ET 0.7, we can set _skip_dim_order=False
+                    _skip_dim_order=True,
                 ),
                 constant_methods=metadata,
             ).to_executorch(

--- a/optimum/exporters/executorch/recipes/coreml.py
+++ b/optimum/exporters/executorch/recipes/coreml.py
@@ -76,7 +76,7 @@ def export_to_executorch_with_coreml(
         ]
         for k in kwargs:
             if k not in valid_kwargs:
-                raise ValueError(f"Invalid keyword argument {k} for CoreML recipe")
+                raise ValueError(f"Invalid keyword argument {k} for CoreML recipe. Valid arguments are {valid_kwargs}")
 
         compute_unit = kwargs.get("compute_unit", ct.ComputeUnit.ALL)
         minimum_deployment_target = kwargs.get("minimum_deployment_target", ct.target.iOS15)
@@ -92,12 +92,22 @@ def export_to_executorch_with_coreml(
 
         op_linear_quantizer_config = None
         quant_recipe = kwargs.get("quant_recipe", None)
-        if quant_recipe == "weight_only:8bit:per_channel":
-            op_linear_quantizer_config = {
+        valid_quant_recipes = {
+            "8bit": {
                 "mode": "linear_symmetric",
                 "dtype": "int8",
                 "granularity": "per_channel",
+            },
+            "4bit": {
+                "mode": "linear_symmetric",
+                "dtype": "int4",
+                "granularity": "per_block",
+                "block_size": 32,
             }
+        }
+        if quant_recipe not in valid_quant_recipes:
+            raise ValueError(f"Invalid quant recipe {quant_recipe}, must be one of {valid_quant_recipes.keys()}")
+        op_linear_quantizer_config = valid_quant_recipes.get(quant_recipe, None)
 
         et_progs = {}
         backend_config_dict = {}

--- a/optimum/exporters/executorch/recipes/coreml.py
+++ b/optimum/exporters/executorch/recipes/coreml.py
@@ -66,6 +66,18 @@ def export_to_executorch_with_coreml(
         metadata=None,
         **kwargs,
     ) -> Dict[str, ExecutorchProgram]:
+        valid_kwargs = [
+            "compute_unit",
+            "minimum_deployment_target",
+            "compute_precision",
+            "model_type",
+            "take_over_mutable_buffer",
+            "quant_recipe",
+        ]
+        for k in kwargs:
+            if k not in valid_kwargs:
+                raise ValueError(f"Invalid keyword argument {k} for CoreML recipe")
+
         compute_unit = kwargs.get("compute_unit", ct.ComputeUnit.ALL)
         minimum_deployment_target = kwargs.get("minimum_deployment_target", ct.target.iOS15)
         compute_precision = kwargs.get("compute_precision", ct.precision.FLOAT16)
@@ -74,7 +86,9 @@ def export_to_executorch_with_coreml(
             "model": CoreMLBackend.MODEL_TYPE.MODEL,
             "modelc": CoreMLBackend.MODEL_TYPE.COMPILED_MODEL,
         }[model_type]
-        take_over_mutable_buffer = kwargs.get("take_over_mutable_buffer", (minimum_deployment_target >= ct.target.iOS18))
+        take_over_mutable_buffer = kwargs.get(
+            "take_over_mutable_buffer", (minimum_deployment_target >= ct.target.iOS18)
+        )
 
         op_linear_quantizer_config = None
         quant_recipe = kwargs.get("quant_recipe", None)

--- a/optimum/exporters/executorch/recipes/coreml.py
+++ b/optimum/exporters/executorch/recipes/coreml.py
@@ -74,7 +74,7 @@ def export_to_executorch_with_coreml(
             "model": CoreMLBackend.MODEL_TYPE.MODEL,
             "modelc": CoreMLBackend.MODEL_TYPE.COMPILED_MODEL,
         }[model_type]
-        take_over_mutable_buffer = kwargs.get("take_over_mutable_buffer", True)
+        take_over_mutable_buffer = kwargs.get("take_over_mutable_buffer", (minimum_deployment_target >= ct.target.iOS18))
 
         op_linear_quantizer_config = None
         quant_recipe = kwargs.get("quant_recipe", None)

--- a/optimum/exporters/executorch/recipes/coreml.py
+++ b/optimum/exporters/executorch/recipes/coreml.py
@@ -96,7 +96,7 @@ def _export_to_executorch(
         backend_config_dict = {}
         for pte_name, exported_program in exported_programs.items():
             exported_program = exported_program.run_decompositions({})
-            logging.debug(f"\nExported program for {pte_name}.pte: {exported_program}")
+            print(f"\nExported program for {pte_name}.pte: {exported_program}")
             et_progs[pte_name] = to_edge_transform_and_lower(
                 exported_program,
                 partitioner=[
@@ -124,12 +124,12 @@ def _export_to_executorch(
             ).to_executorch(
                 config=ExecutorchBackendConfig(**backend_config_dict),
             )
-            logging.debug(
+            print(
                 f"\nExecuTorch program for {pte_name}.pte: {et_progs[pte_name].exported_program().graph_module}"
             )
             delegation_info = get_delegation_info(et_progs[pte_name].exported_program().graph_module)
-            logging.debug(f"\nDelegation info Summary for {pte_name}.pte: {delegation_info.get_summary()}")
-            logging.debug(
+            print(f"\nDelegation info Summary for {pte_name}.pte: {delegation_info.get_summary()}")
+            print(
                 f"\nDelegation info for {pte_name}.pte: {tabulate(delegation_info.get_operator_delegation_dataframe(), headers='keys', tablefmt='fancy_grid')}"
             )
         return et_progs

--- a/optimum/exporters/executorch/recipes/coreml.py
+++ b/optimum/exporters/executorch/recipes/coreml.py
@@ -103,7 +103,7 @@ def export_to_executorch_with_coreml(
                 "dtype": "int4",
                 "granularity": "per_block",
                 "block_size": 32,
-            }
+            },
         }
         if quant_recipe is not None and quant_recipe not in valid_quant_recipes:
             raise ValueError(f"Invalid quant recipe {quant_recipe}, must be one of {valid_quant_recipes.keys()}")

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ INSTALL_REQUIRE = [
 
 TESTS_REQUIRE = [
     "accelerate>=0.26.0",
-    "coremltools>=8.2.0",
+    "coremltools>=8.3.0",
     "datasets",
     "parameterized",
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ INSTALL_REQUIRE = [
 
 TESTS_REQUIRE = [
     "accelerate>=0.26.0",
-    "coremltools>=8.3.0",
+    "coremltools>=8.2.0",
     "datasets",
     "parameterized",
     "pytest",

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -146,6 +146,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe_kwargs={
                 "compute_precision": ct.precision.FLOAT32,
                 "take_over_mutable_buffer": False,
+                "minimum_deployment_target": ct.target.iOS18,
             },
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
@@ -156,6 +157,41 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             max_seq_len=32,
         )
         logging.info(f"\nGenerated text:\n\t{generated_text}")
+        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
+
+        # Free memory before loading eager for quality check
+        del model
+        del tokenizer
+        gc.collect()
+
+        self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.skipif(is_not_macos, reason="Only runs on MacOS")
+    def test_llama_text_generation_with_coreml_8bit(self):
+        import coremltools as ct
+
+        model_id = "NousResearch/Llama-3.2-1B"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model = ExecuTorchModelForCausalLM.from_pretrained(
+            model_id,
+            recipe="coreml",
+            recipe_kwargs={
+                "compute_precision": ct.precision.FLOAT32,
+                "take_over_mutable_buffer": False,
+                "quant_recipe": "weight_only:8bit:per_channel",
+            },
+        )
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+        generated_text = model.text_generation(
+            tokenizer=tokenizer,
+            prompt="Simply put, the theory of relativity states that",
+            max_seq_len=32,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")
+        print(generated_text)
         generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
 
         # Free memory before loading eager for quality check

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -17,7 +17,6 @@ import gc
 import logging
 import os
 import subprocess
-import sys
 import tempfile
 import unittest
 
@@ -31,9 +30,6 @@ from transformers.testing_utils import slow
 from optimum.executorch import ExecuTorchModelForCausalLM
 
 from ..utils import check_causal_lm_output_quality
-
-
-is_not_macos = sys.platform != "darwin"
 
 
 @pytest.mark.skipif(
@@ -123,75 +119,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             max_seq_len=32,
         )
         logging.info(f"\nGenerated text:\n\t{generated_text}")
-        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
-
-        # Free memory before loading eager for quality check
-        del model
-        del tokenizer
-        gc.collect()
-
-        self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
-
-    @slow
-    @pytest.mark.run_slow
-    @pytest.mark.skipif(is_not_macos, reason="Only runs on MacOS")
-    def test_llama_text_generation_with_coreml_fp32(self):
-        import coremltools as ct
-
-        model_id = "NousResearch/Llama-3.2-1B"
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_id,
-            recipe="coreml",
-            recipe_kwargs={
-                "compute_precision": ct.precision.FLOAT32,
-                "take_over_mutable_buffer": False,
-                "minimum_deployment_target": ct.target.iOS18,
-            },
-        )
-        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
-        self.assertIsInstance(model.model, ExecuTorchModule)
-        generated_text = model.text_generation(
-            tokenizer=tokenizer,
-            prompt="Simply put, the theory of relativity states that",
-            max_seq_len=32,
-        )
-        logging.info(f"\nGenerated text:\n\t{generated_text}")
-        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
-
-        # Free memory before loading eager for quality check
-        del model
-        del tokenizer
-        gc.collect()
-
-        self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
-
-    @slow
-    @pytest.mark.run_slow
-    @pytest.mark.skipif(is_not_macos, reason="Only runs on MacOS")
-    def test_llama_text_generation_with_coreml_8bit(self):
-        import coremltools as ct
-
-        model_id = "NousResearch/Llama-3.2-1B"
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_id,
-            recipe="coreml",
-            recipe_kwargs={
-                "compute_precision": ct.precision.FLOAT32,
-                "take_over_mutable_buffer": False,
-                "quant_recipe": "weight_only:8bit:per_channel",
-            },
-        )
-        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
-        self.assertIsInstance(model.model, ExecuTorchModule)
-        generated_text = model.text_generation(
-            tokenizer=tokenizer,
-            prompt="Simply put, the theory of relativity states that",
-            max_seq_len=32,
-        )
-        logging.info(f"\nGenerated text:\n\t{generated_text}")
-        print(generated_text)
         generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
 
         # Free memory before loading eager for quality check

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -135,7 +135,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.skipif(is_not_macos, reason="Only runs on MacOS")
-    def test_llama_text_generation_with_coreml(self):
+    def test_llama_text_generation_with_coreml_fp32(self):
         import coremltools as ct
 
         model_id = "NousResearch/Llama-3.2-1B"
@@ -144,8 +144,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             model_id,
             recipe="coreml",
             recipe_kwargs={
-                "compute_precision": ct.precision.FLOAT16,
-                "compute_units": ct.ComputeUnit.ALL,
+                "compute_precision": ct.precision.FLOAT32,
                 "take_over_mutable_buffer": False,
             },
         )

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -135,7 +135,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.skipif(is_not_macos, reason="Only runs on MacOS")
-    def test_llama_text_generation_with_coreml_8bit(self):
+    def test_llama_text_generation_with_coreml_4bit(self):
         import coremltools as ct
 
         model_id = "NousResearch/Llama-3.2-1B"

--- a/tests/models/test_modeling_llama.py
+++ b/tests/models/test_modeling_llama.py
@@ -17,6 +17,7 @@ import gc
 import logging
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -30,6 +31,9 @@ from transformers.testing_utils import slow
 from optimum.executorch import ExecuTorchModelForCausalLM
 
 from ..utils import check_causal_lm_output_quality
+
+
+is_not_macos = sys.platform != "darwin"
 
 
 @pytest.mark.skipif(
@@ -110,6 +114,40 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             attn_implementation="custom_sdpa",
             use_custom_kv_cache=True,
             **{"qlinear": True, "qembeeding": True},
+        )
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+        generated_text = model.text_generation(
+            tokenizer=tokenizer,
+            prompt="Simply put, the theory of relativity states that",
+            max_seq_len=32,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")
+        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
+
+        # Free memory before loading eager for quality check
+        del model
+        del tokenizer
+        gc.collect()
+
+        self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.skipif(is_not_macos, reason="Only runs on MacOS")
+    def test_llama_text_generation_with_coreml(self):
+        import coremltools as ct
+
+        model_id = "NousResearch/Llama-3.2-1B"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model = ExecuTorchModelForCausalLM.from_pretrained(
+            model_id,
+            recipe="coreml",
+            recipe_kwargs={
+                "compute_precision": ct.precision.FLOAT16,
+                "compute_units": ct.ComputeUnit.ALL,
+                "take_over_mutable_buffer": False,
+            },
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)

--- a/tests/models/test_modeling_smollm.py
+++ b/tests/models/test_modeling_smollm.py
@@ -240,8 +240,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             recipe="coreml",
             recipe_kwargs={
                 "compute_precision": ct.precision.FLOAT32,
+                # In ET 0.7 we can set take_over_mutable_buffer to True
                 "take_over_mutable_buffer": False,
-                "quant_recipe": "weight_only:8bit:per_channel",
+                "minimum_deployment_target": ct.target.iOS18,
+                "quant_recipe": "8bit",
             },
         )
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)

--- a/tests/models/test_modeling_vit.py
+++ b/tests/models/test_modeling_vit.py
@@ -128,7 +128,3 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/models/test_modeling_vit.py
+++ b/tests/models/test_modeling_vit.py
@@ -95,7 +95,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         et_model = ExecuTorchModelForImageClassification.from_pretrained(
             model_id=model_id,
             recipe="coreml",
-            recipe_kwargs={"compute_precision": ct.precision.FLOAT32, "compute_units": ct.ComputeUnit.CPU_ONLY},
+            recipe_kwargs={"compute_precision": ct.precision.FLOAT32, "compute_unit": ct.ComputeUnit.CPU_ONLY},
         )
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)


### PR DESCRIPTION
This adds weight-only 4bit/8bit quantization for coreml.  It builds on https://github.com/huggingface/optimum-executorch/pull/91.

For llama, CoreML needs to use FP32 arithmetic for decent quality.