### PR TITLE
Add portable recipe and tests

### DIFF
--- a/optimum/exporters/executorch/recipes/portable.py
+++ b/optimum/exporters/executorch/recipes/portable.py
@@ -1,0 +1,94 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Dict, Union
+
+from torch.export import ExportedProgram
+
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchProgram,
+    to_edge_transform_and_lower,
+)
+from optimum.executorch.passes.remove_padding_idx_embedding_pass import RemovePaddingIdxEmbeddingPass
+
+from ..integrations import (
+    CausalLMExportableModule,
+    MaskedLMExportableModule,
+    Seq2SeqLMExportableModule,
+)
+from ..recipe_registry import register_recipe
+
+
+@register_recipe("portable")
+def export_to_executorch_with_portable(
+    model: Union[CausalLMExportableModule, MaskedLMExportableModule, Seq2SeqLMExportableModule],
+    **kwargs,
+):
+    """
+    Export a PyTorch model to ExecuTorch with Portable kernels.
+
+    This function also write metadata required by the ExecuTorch runtime to the model.
+
+    Args:
+        model (Union[CausalLMExportableModule, MaskedLMExportableModule, Seq2SeqLMExportableModule]):
+            The PyTorch model to be exported to ExecuTorch.
+        **kwargs:
+            Additional keyword arguments for recipe-specific configurations, e.g. export using different example inputs, or different compile/bechend configs.
+
+    Returns:
+        Dict[str, ExecutorchProgram]:
+            A map of exported and optimized program for ExecuTorch.
+            For encoder-decoder models or multimodal models, it may generate multiple programs.
+    """
+
+    def _lower_to_executorch(
+        exported_programs: Dict[str, ExportedProgram],
+        metadata=None,
+    ) -> Dict[str, ExecutorchProgram]:
+        et_progs = {}
+
+        for pte_name, exported_program in exported_programs.items():
+            logging.debug(f"\nExported program for {pte_name}.pte: {exported_program}")
+            et_progs[pte_name] = to_edge_transform_and_lower(
+                exported_program,
+                partitioner=[],
+                compile_config=EdgeCompileConfig(
+                    _check_ir_validity=False,
+                    _skip_dim_order=True,
+                ),
+                constant_methods=metadata,
+                transform_passes=[RemovePaddingIdxEmbeddingPass()],
+            ).to_executorch()
+            logging.debug(
+                f"\nExecuTorch program for {pte_name}.pte: {et_progs[pte_name].exported_program().graph_module}"
+            )
+        return et_progs
+
+    exported_progs = model.export()
+
+    if (
+        model.config._attn_implementation == "custom_sdpa"
+        or model.config._attn_implementation == "custom_sdpa_ring_kv_cache"
+    ):
+        # Sanity check to make sure the exported program contains the custom sdpa operator.
+        if not any(
+            node.op == "call_function" and "custom_sdpa" in str(node.target)
+            for exported_program in exported_progs.values()
+            for node in exported_program.graph_module.graph.nodes
+        ):
+            raise ValueError("'custom_sdpa' not found in the graph.")
+
+    return _lower_to_executorch(exported_progs, model.metadata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ known-first-party = ["optimum"]
 [tool.pytest.ini_options]
 markers = [
     "run_slow",
+    "portable",
 ]

--- a/tests/models/test_modeling_albert.py
+++ b/tests/models/test_modeling_albert.py
@@ -45,14 +45,12 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_albert_fill_mask(self):
+    def _helper_albert_fill_mask(self, recipe: str):
         model_id = "albert/albert-base-v2"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         # Test fetching and lowering the model to ExecuTorch
-        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe="xnnpack")
+        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForMaskedLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -72,3 +70,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             any(word in predicted_masks for word in ["capital", "center", "heart", "birthplace"]),
             f"Exported model predictions {predicted_masks} don't contain any of the most common expected words",
         )
+
+    @slow
+    @pytest.mark.run_slow
+    def test_albert_fill_mask(self):
+        self._helper_albert_fill_mask("xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_albert_fill_mask_portable(self):
+        self._helper_albert_fill_mask("portable")

--- a/tests/models/test_modeling_bert.py
+++ b/tests/models/test_modeling_bert.py
@@ -45,14 +45,12 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_bert_fill_mask(self):
+    def _helper_bert_fill_mask(self, recipe: str):
         model_id = "google-bert/bert-base-uncased"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         # Test fetching and lowering the model to ExecuTorch
-        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe="xnnpack")
+        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForMaskedLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -72,3 +70,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             any(word in predicted_masks for word in ["capital", "center", "heart", "birthplace"]),
             f"Exported model predictions {predicted_masks} don't contain any of the most common expected words",
         )
+
+    @slow
+    @pytest.mark.run_slow
+    def test_bert_fill_mask(self):
+        self._helper_bert_fill_mask("xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_bert_fill_mask_portable(self):
+        self._helper_bert_fill_mask("portable")

--- a/tests/models/test_modeling_cvt.py
+++ b/tests/models/test_modeling_cvt.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_cvt_image_classification(self):
+    def _helper_cvt_image_classification(self, recipe: str):
         model_id = "microsoft/cvt-13"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_cvt_image_classification(self):
+        self._helper_cvt_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_cvt_image_classification_portable(self):
+        self._helper_cvt_image_classification(recipe="portable")

--- a/tests/models/test_modeling_deit.py
+++ b/tests/models/test_modeling_deit.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_deit_image_classification(self):
+    def _helper_deit_image_classification(self, recipe: str):
         model_id = "facebook/deit-base-distilled-patch16-224"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_deit_image_classification(self):
+        self._helper_deit_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_deit_image_classification_portable(self):
+        self._helper_deit_image_classification(recipe="portable")

--- a/tests/models/test_modeling_distilbert.py
+++ b/tests/models/test_modeling_distilbert.py
@@ -45,14 +45,12 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_distilbert_fill_mask(self):
+    def _helper_distilbert_fill_mask(self, recipe: str):
         model_id = "distilbert/distilbert-base-uncased"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         # Test fetching and lowering the model to ExecuTorch
-        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe="xnnpack")
+        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForMaskedLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -72,3 +70,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             any(word in predicted_masks for word in ["capital", "center", "heart", "birthplace"]),
             f"Exported model predictions {predicted_masks} don't contain any of the most common expected words",
         )
+
+    @slow
+    @pytest.mark.run_slow
+    def test_distilbert_fill_mask(self):
+        self._helper_distilbert_fill_mask(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_distilbert_fill_mask_portable(self):
+        self._helper_distilbert_fill_mask(recipe="portable")

--- a/tests/models/test_modeling_dit.py
+++ b/tests/models/test_modeling_dit.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_dit_image_classification(self):
+    def _helper_dit_image_classification(self, recipe: str):
         model_id = "microsoft/dit-base-finetuned-rvlcdip"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_dit_image_classification(self):
+        self._helper_dit_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_dit_image_classification_portable(self):
+        self._helper_dit_image_classification(recipe="portable")

--- a/tests/models/test_modeling_efficientnet.py
+++ b/tests/models/test_modeling_efficientnet.py
@@ -48,13 +48,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    @pytest.mark.skipif(
-        version.__version__ < "0.6.0",
-        reason="The fix in XNNPACK is cherry-picked in 0.6.0 release",
-    )
-    def test_efficientnet_image_classification(self):
+    def _helper_efficientnet_image_classification(self, recipe: str):
         model_id = "google/efficientnet-b0"  # ~5.3M params
 
         config = AutoConfig.from_pretrained(model_id)
@@ -65,7 +59,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -76,3 +70,18 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.skipif(
+        version.__version__ < "0.6.0",
+        reason="The fix in XNNPACK is cherry-picked in 0.6.0 release",
+    )
+    def test_efficientnet_image_classification(self):
+        self._helper_efficientnet_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_efficientnet_image_classification_portable(self):
+        self._helper_efficientnet_image_classification(recipe="portable")

--- a/tests/models/test_modeling_focalnet.py
+++ b/tests/models/test_modeling_focalnet.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_focalnet_image_classification(self):
+    def _helper_focalnet_image_classification(self, recipe: str):
         model_id = "microsoft/focalnet-tiny"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_focalnet_image_classification(self):
+        self._helper_focalnet_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_focalnet_image_classification_portable(self):
+        self._helper_focalnet_image_classification(recipe="portable")

--- a/tests/models/test_modeling_gemma.py
+++ b/tests/models/test_modeling_gemma.py
@@ -90,3 +90,22 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             max_seq_len=21,
         )
         logging.info(f"\nGenerated text:\n\t{generated_text}")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_gemma_text_generation_portable(self):
+        # TODO: Switch to use google/gemma-2b once https://github.com/huggingface/optimum/issues/2127 is fixed
+        # model_id = "google/gemma-2b"
+        model_id = "weqweasdas/RM-Gemma-2B"
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="portable")
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        generated_text = model.text_generation(
+            tokenizer=tokenizer,
+            prompt="Hello I am doing",
+            max_seq_len=21,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")

--- a/tests/models/test_modeling_gemma3.py
+++ b/tests/models/test_modeling_gemma3.py
@@ -79,17 +79,11 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                 os.remove(pte_full_path)
             gc.collect()
 
-    @slow
-    @pytest.mark.run_slow
-    @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
-    def test_gemma3_text_generation(self):
+    def _helper_gemma3_text_generation(self, recipe: str):
         # TODO: Until https://github.com/huggingface/optimum/issues/2127 is fixed, have to use non-gated model on CI
         # model_id = "google/gemma-3-1b-it"
         model_id = "unsloth/gemma-3-1b-it"
-        model = ExecuTorchModelForCausalLM.from_pretrained(
-            model_id,
-            recipe="xnnpack",
-        )
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -108,6 +102,19 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         gc.collect()
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
+    def test_gemma3_text_generation(self):
+        self._helper_gemma3_text_generation(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
+    def test_gemma3_text_generation_portable(self):
+        self._helper_gemma3_text_generation(recipe="portable")
 
     @slow
     @pytest.mark.run_slow

--- a/tests/models/test_modeling_mobilevit.py
+++ b/tests/models/test_modeling_mobilevit.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_mobilevit_image_classification(self):
+    def _helper_mobilevit_image_classification(self, recipe: str):
         model_id = "apple/mobilevit-xx-small"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_mobilevit_image_classification(self):
+        self._helper_mobilevit_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_mobilevit_image_classification_portable(self):
+        self._helper_mobilevit_image_classification(recipe="portable")

--- a/tests/models/test_modeling_mobilevit2.py
+++ b/tests/models/test_modeling_mobilevit2.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_mobilevit2_image_classification(self):
+    def _helper_mobilevit2_image_classification(self, recipe: str):
         model_id = "apple/mobilevitv2-1.0-imagenet1k-256"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output, atol=1e-3, rtol=1e-3))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_mobilevit2_image_classification(self):
+        self._helper_mobilevit2_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_mobilevit2_image_classification_portable(self):
+        self._helper_mobilevit2_image_classification(recipe="portable")

--- a/tests/models/test_modeling_olmo.py
+++ b/tests/models/test_modeling_olmo.py
@@ -148,3 +148,29 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         gc.collect()
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
+    def test_olmo_text_generation_portable(self):
+        model_id = "allenai/OLMo-1B-hf"
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="portable")
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        generated_text = model.text_generation(
+            tokenizer=tokenizer,
+            prompt="Simply put, the theory of relativity states that",
+            max_seq_len=32,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")
+        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
+
+        # Free memory before loading eager for quality check
+        del model
+        del tokenizer
+        gc.collect()
+
+        self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))

--- a/tests/models/test_modeling_phi4.py
+++ b/tests/models/test_modeling_phi4.py
@@ -167,3 +167,30 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                     generated_tokens,
                 )
             )
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_phi4_text_generation_portable(self):
+        model_id = "microsoft/Phi-4-mini-instruct"
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="portable")
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        generated_text = model.text_generation(
+            tokenizer=tokenizer,
+            prompt="My favourite condiment is ",
+            max_seq_len=64,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")
+
+        if not is_ci:
+            generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
+
+            # Free memory before loading eager for quality check
+            del model
+            del tokenizer
+            gc.collect()
+
+            self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))

--- a/tests/models/test_modeling_pvt.py
+++ b/tests/models/test_modeling_pvt.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_pvt_image_classification(self):
+    def _helper_pvt_image_classification(self, recipe: str):
         model_id = "Zetatech/pvt-tiny-224"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_pvt_image_classification(self):
+        self._helper_pvt_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_pvt_image_classification_portable(self):
+        self._helper_pvt_image_classification(recipe="portable")

--- a/tests/models/test_modeling_qwen2.py
+++ b/tests/models/test_modeling_qwen2.py
@@ -51,11 +51,9 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_qwen2_5_text_generation(self):
+    def _helper_qwen2_5_text_generation(self, recipe: str):
         model_id = "Qwen/Qwen2.5-0.5B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -74,6 +72,17 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         gc.collect()
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_qwen2_5_text_generation(self):
+        self._helper_qwen2_5_text_generation(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_qwen2_5_text_generation_portable(self):
+        self._helper_qwen2_5_text_generation(recipe="portable")
 
     @slow
     @pytest.mark.run_slow

--- a/tests/models/test_modeling_qwen3.py
+++ b/tests/models/test_modeling_qwen3.py
@@ -68,12 +68,9 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
-    def test_qwen3_text_generation(self):
+    def _helper_qwen3_text_generation(self, recipe: str):
         model_id = "Qwen/Qwen3-0.6B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -92,6 +89,19 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         gc.collect()
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
+    def test_qwen3_text_generation(self):
+        self._helper_qwen3_text_generation(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    @pytest.mark.skipif(is_linux_ci, reason="OOM on linux runner")
+    def test_qwen3_text_generation_portable(self):
+        self._helper_qwen3_text_generation(recipe="portable")
 
     @slow
     @pytest.mark.run_slow

--- a/tests/models/test_modeling_roberta.py
+++ b/tests/models/test_modeling_roberta.py
@@ -45,14 +45,12 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_roberta_fill_mask(self):
+    def _helper_roberta_fill_mask(self, recipe: str):
         model_id = "FacebookAI/xlm-roberta-base"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         # Test fetching and lowering the model to ExecuTorch
-        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe="xnnpack")
+        model = ExecuTorchModelForMaskedLM.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForMaskedLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -72,3 +70,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             any(word in predicted_masks for word in ["capital", "center", "heart", "birthplace"]),
             f"Exported model predictions {predicted_masks} don't contain any of the most common expected words",
         )
+
+    @slow
+    @pytest.mark.run_slow
+    def test_roberta_fill_mask(self):
+        self._helper_roberta_fill_mask(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_roberta_fill_mask_portable(self):
+        self._helper_roberta_fill_mask(recipe="portable")

--- a/tests/models/test_modeling_smollm.py
+++ b/tests/models/test_modeling_smollm.py
@@ -59,11 +59,9 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_smollm_text_generation(self):
+    def _helper_smollm_text_generation(self, recipe: str):
         model_id = "HuggingFaceTB/SmolLM2-135M"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="xnnpack")
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe=recipe)
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -82,6 +80,17 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         gc.collect()
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_smollm_text_generation(self):
+        self._helper_smollm_text_generation(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_smollm_text_generation_portable(self):
+        self._helper_smollm_text_generation(recipe="portable")
 
     @slow
     @pytest.mark.run_slow

--- a/tests/models/test_modeling_smollm3.py
+++ b/tests/models/test_modeling_smollm3.py
@@ -72,3 +72,28 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         gc.collect()
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_smollm3_text_generation_portable(self):
+        model_id = "HuggingFaceTB/SmolLM3-3B"
+        prompt = "Give me a brief explanation of gravity in simple terms."
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe="portable")
+        self.assertIsInstance(model, ExecuTorchModelForCausalLM)
+        self.assertIsInstance(model.model, ExecuTorchModule)
+        generated_text = model.text_generation(
+            tokenizer=tokenizer,
+            prompt=prompt,
+            max_seq_len=64,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")
+        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
+
+        # Free memory before loading eager for quality check
+        del model
+        del tokenizer
+        gc.collect()
+
+        self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))

--- a/tests/models/test_modeling_swin.py
+++ b/tests/models/test_modeling_swin.py
@@ -47,9 +47,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_swin_image_classification(self):
+    def _helper_swin_image_classification(self, recipe: str):
         model_id = "microsoft/swin-tiny-patch4-window7-224"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -60,7 +58,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -71,3 +69,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_swin_image_classification(self):
+        self._helper_swin_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_swin_image_classification_portable(self):
+        self._helper_swin_image_classification(recipe="portable")

--- a/tests/models/test_modeling_t5.py
+++ b/tests/models/test_modeling_t5.py
@@ -46,12 +46,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/encoder.pte"))
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/decoder.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_t5_translation(self):
+    def _helper_t5_translation(self, recipe: str):
         model_id = "google/flan-t5-small"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = ExecuTorchModelForSeq2SeqLM.from_pretrained(model_id, recipe="xnnpack")
+        model = ExecuTorchModelForSeq2SeqLM.from_pretrained(model_id, recipe=recipe)
 
         self.assertIsInstance(model, ExecuTorchModelForSeq2SeqLM)
         self.assertTrue(hasattr(model, "encoder"))
@@ -70,10 +68,19 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
     @slow
     @pytest.mark.run_slow
-    def test_t5_summarization(self):
+    def test_t5_translation(self):
+        self._helper_t5_translation(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_t5_translation_portable(self):
+        self._helper_t5_translation(recipe="portable")
+
+    def _helper_t5_summarization(self, recipe: str):
         model_id = "google-t5/t5-small"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = ExecuTorchModelForSeq2SeqLM.from_pretrained(model_id, recipe="xnnpack")
+        model = ExecuTorchModelForSeq2SeqLM.from_pretrained(model_id, recipe=recipe)
 
         self.assertIsInstance(model, ExecuTorchModelForSeq2SeqLM)
         self.assertTrue(hasattr(model, "encoder"))
@@ -114,3 +121,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         expected_text = 'a year later, she got married again in westchester county, new york. she was married to a different man, but only 18 days after that marriage. she is facing two criminal counts of "offering a false instrument"'
         logging.info(f"\nInput text:\n\t{article}\nGenerated text:\n\t{generated_text}")
         self.assertEqual(generated_text, expected_text)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_t5_summarization(self):
+        self._helper_t5_summarization(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_t5_summarization_portable(self):
+        self._helper_t5_summarization(recipe="portable")

--- a/tests/models/test_modeling_vit.py
+++ b/tests/models/test_modeling_vit.py
@@ -51,9 +51,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_vit_image_classification(self):
+    def _helper_vit_image_classification(self, recipe: str):
         model_id = "google/vit-base-patch16-224"
 
         config = AutoConfig.from_pretrained(model_id)
@@ -64,7 +62,7 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         pixel_values = torch.rand(batch_size, num_channels, height, width)
 
         # Test fetching and lowering the model to ExecuTorch
-        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe="xnnpack")
+        et_model = ExecuTorchModelForImageClassification.from_pretrained(model_id=model_id, recipe=recipe)
         self.assertIsInstance(et_model, ExecuTorchModelForImageClassification)
         self.assertIsInstance(et_model.model, ExecuTorchModule)
 
@@ -75,6 +73,17 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
 
         # Compare with eager outputs
         self.assertTrue(check_close_recursively(eager_output.logits, et_output))
+
+    @slow
+    @pytest.mark.run_slow
+    def test_vit_image_classification(self):
+        self._helper_vit_image_classification(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_vit_image_classification_portable(self):
+        self._helper_vit_image_classification(recipe="portable")
 
     @slow
     @pytest.mark.run_slow

--- a/tests/models/test_modeling_whisper.py
+++ b/tests/models/test_modeling_whisper.py
@@ -55,12 +55,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/encoder.pte"))
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/decoder.pte"))
 
-    @slow
-    @pytest.mark.run_slow
-    def test_whisper_transcription(self):
+    def _helper_whisper_transcription(self, recipe: str):
         model_id = "openai/whisper-tiny"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = ExecuTorchModelForSpeechSeq2Seq.from_pretrained(model_id, recipe="xnnpack")
+        model = ExecuTorchModelForSpeechSeq2Seq.from_pretrained(model_id, recipe=recipe)
         processor = AutoProcessor.from_pretrained(model_id)
 
         self.assertIsInstance(model, ExecuTorchModelForSpeechSeq2Seq)
@@ -84,3 +82,14 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             f"\nExpected transcription:\n\t{expected_text}\nGenerated transcription:\n\t{generated_transcription}"
         )
         self.assertEqual(generated_transcription, expected_text)
+
+    @slow
+    @pytest.mark.run_slow
+    def test_whisper_transcription(self):
+        self._helper_whisper_transcription(recipe="xnnpack")
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.portable
+    def test_whisper_transcription_portable(self):
+        self._helper_whisper_transcription(recipe="portable")


### PR DESCRIPTION
This PR introduced a new portable recipe, intended to test model coverage of ExecuTorch portable kernels.
Tests have been added for each currently supported model. A portable marker has been incorporated into the pytest configuration within pyproject.toml, enabling the selection and running of portable tests only.