### PR TITLE
Support running ptes for tasks with multiple models

### DIFF
--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -337,20 +337,23 @@ class ExecuTorchModelBase(OptimizedModel, ABC):
                 f"Could not infer whether the model was already converted or not to the ExecuTorch IR, keeping `export={export}`.\n{exception}"
             )
 
-        from_pretrained_method = cls._export if _export else cls._from_pretrained
-
-        models_dict = from_pretrained_method(
-            model_id=model_id,
-            config=config,
-            revision=revision,
-            cache_dir=cache_dir,
-            force_download=force_download,
-            token=token,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-            trust_remote_code=trust_remote_code,
-            **kwargs,
-        )
+        if _export:
+            models_dict = cls._export(
+                model_id=model_id,
+                config=config,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                token=token,
+                subfolder=subfolder,
+                local_files_only=local_files_only,
+                trust_remote_code=trust_remote_code,
+                **kwargs,
+            )
+        else:
+            models_dict = {}
+            for pte_file in pte_files:
+                models_dict.update(cls._from_pretrained(model_id, file_name=pte_file.name, config=config))
 
         return cls(models_dict, config)
 

--- a/tests/models/test_modeling_qwen3.py
+++ b/tests/models/test_modeling_qwen3.py
@@ -68,10 +68,10 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
                 check=True,
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/model.pte"))
+            model = ExecuTorchModelForCausalLM.from_pretrained(f"{tempdir}/executorch")
+            self._test_qwen3_text_generation(model_id, model)
 
-    def _helper_qwen3_text_generation(self, recipe: str):
-        model_id = "Qwen/Qwen3-0.6B"
-        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe=recipe)
+    def _test_qwen3_text_generation(self, model_id: str, model: ExecuTorchModelForCausalLM):
         self.assertIsInstance(model, ExecuTorchModelForCausalLM)
         self.assertIsInstance(model.model, ExecuTorchModule)
 
@@ -90,6 +90,11 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         gc.collect()
 
         self.assertTrue(check_causal_lm_output_quality(model_id, generated_tokens))
+
+    def _helper_qwen3_text_generation(self, recipe: str):
+        model_id = "Qwen/Qwen3-0.6B"
+        model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe=recipe)
+        self._test_qwen3_text_generation(model_id, model)
 
     @slow
     @pytest.mark.run_slow

--- a/tests/models/test_modeling_whisper.py
+++ b/tests/models/test_modeling_whisper.py
@@ -42,8 +42,8 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @slow
-    @pytest.mark.run_slow
+    # @slow
+    # @pytest.mark.run_slow
     def test_whisper_export_to_executorch(self):
         model_id = "openai/whisper-tiny"
         task = "automatic-speech-recognition"
@@ -56,11 +56,11 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             )
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/encoder.pte"))
             self.assertTrue(os.path.exists(f"{tempdir}/executorch/decoder.pte"))
+            model = ExecuTorchModelForSpeechSeq2Seq.from_pretrained(f"{tempdir}/executorch")
+            self._test_whisper_transcription(model_id, model)
 
-    def _helper_whisper_transcription(self, recipe: str):
-        model_id = "openai/whisper-tiny"
+    def _test_whisper_transcription(self, model_id: str, model: ExecuTorchModelForSpeechSeq2Seq):
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = ExecuTorchModelForSpeechSeq2Seq.from_pretrained(model_id, recipe=recipe)
         processor = AutoProcessor.from_pretrained(model_id)
 
         self.assertIsInstance(model, ExecuTorchModelForSpeechSeq2Seq)
@@ -84,6 +84,11 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
             f"\nExpected transcription:\n\t{expected_text}\nGenerated transcription:\n\t{generated_transcription}"
         )
         self.assertEqual(generated_transcription, expected_text)
+
+    def _helper_whisper_transcription(self, recipe: str):
+        model_id = "openai/whisper-tiny"
+        model = ExecuTorchModelForSpeechSeq2Seq.from_pretrained(model_id, recipe=recipe)
+        self._test_whisper_transcription(model_id, model)
 
     @slow
     @pytest.mark.run_slow


### PR DESCRIPTION
Previously using ExecuTorchModelForSpeechSeq2Seq.from_pretrained didn't work because there are separate encoder.pte and decoder.pte files.

This PR adds support and new CI tests.