### PR TITLE
Bump transformers to 4.56.1

### DIFF
--- a/install_dev.py
+++ b/install_dev.py
@@ -34,7 +34,7 @@ def install_dep_from_source():
             "-m",
             "pip",
             "install",
-            "git+https://github.com/huggingface/transformers@9c641dc16154964e5ffc0c13e9ec6aaffa295ed6#egg=transformers",  # 4.54.1
+            "git+https://github.com/huggingface/transformers@91393fe4cc3266a05bc0d129e34ff5f761bb46e2#egg=transformers",  # 4.56.1
         ]
     )
     subprocess.check_call(

--- a/optimum/commands/export/executorch.py
+++ b/optimum/commands/export/executorch.py
@@ -120,6 +120,12 @@ def parse_args_executorch(parser):
     required_group.add_argument(
         "--qembedding_group_size", type=int, required=False, help="Group size for embedding quantization."
     )
+    required_group.add_argument(
+        "--max_seq_len",
+        type=int,
+        required=False,
+        help="Maximum sequence length for the model. If not specified, uses the model's default max_position_embeddings.",
+    )
 
 
 class ExecuTorchExportCommand(BaseOptimumCLICommand):
@@ -143,6 +149,8 @@ class ExecuTorchExportCommand(BaseOptimumCLICommand):
             kwargs["qlinear"] = self.args.qlinear
         if self.args.qembedding:
             kwargs["qembedding"] = self.args.qembedding
+        if self.args.max_seq_len:
+            kwargs["max_seq_len"] = self.args.max_seq_len
 
         main_export(
             model_name_or_path=self.args.model,

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -37,7 +37,6 @@ class ETCustomStaticCache(StaticCache):
         max_cache_len: Optional[int] = None,
         device: Union[torch.device, str, None] = None,
         dtype: torch.dtype = torch.float32,
-        layer_device_map: Optional[Dict[int, Union[str, torch.device, int]]] = None,
     ):
         super().__init__(
             config=config,
@@ -45,14 +44,16 @@ class ETCustomStaticCache(StaticCache):
             max_cache_len=max_cache_len,
             device=device,
             dtype=dtype,
-            layer_device_map=layer_device_map,
+        )
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.early_initialization(
+            batch_size=max_batch_size, num_heads=num_heads, head_dim=head_dim, dtype=dtype, device=device
         )
 
-        # make sure layer_device_map is none
-        assert layer_device_map is None
         assert device is None or device == "cpu", "Device must be None or 'cpu'"
 
-        # Create a list of CustomKVCache instances, one per layer
+        # Create a list of CustomKVCache instances derived from each layer of the original Transformers cache, one per layer.
         self.kv_cache = torch.nn.ModuleList()
         for layer in self.layers:
             layer_cache = CustomKVCache(
@@ -191,7 +192,6 @@ class ETCustomHybridCache(HybridCache):
         max_cache_len: Optional[int] = None,
         device: Union[torch.device, str, None] = None,
         dtype: torch.dtype = torch.float32,
-        layer_device_map: Optional[Dict[int, Union[str, torch.device, int]]] = None,
     ):
         super().__init__(
             config=config,
@@ -199,10 +199,13 @@ class ETCustomHybridCache(HybridCache):
             max_cache_len=max_cache_len,
             device=device,
             dtype=dtype,
-            layer_device_map=layer_device_map,
+        )
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.early_initialization(
+            batch_size=max_batch_size, num_heads=num_heads, head_dim=head_dim, dtype=dtype, device=device
         )
 
-        assert layer_device_map is None
         assert device is None or device == "cpu", "Device must be None or 'cpu'"
 
         self.cache_position = None

--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -364,8 +364,6 @@ def _replace_with_et_custom_kv_cache(module, config, generation_config, cache_dt
 
     # Check if module has cache (TorchExportableModuleWithHybridCache)
     elif hasattr(module, "cache"):
-        assert isinstance(module.cache, HybridCache), f"Expected HybridCache, got {type(module.cache)}"
-
         # Replace with ETCustomHybridCache
         if getattr(module, "replace_cache", None) is not None:
             hybrid_cache = ETCustomHybridCache(

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -368,14 +368,18 @@ class CausalLMExportableModule(torch.nn.Module):
     This module ensures that the exported model is compatible with ExecuTorch.
     """
 
-    def __init__(self, model, use_custom_kv_cache=False, use_custom_sdpa=False, disable_dynamic_shapes=False):
+    def __init__(
+        self, model, max_seq_len=2048, use_custom_kv_cache=False, use_custom_sdpa=False, disable_dynamic_shapes=False
+    ):
         super().__init__()
         self.model = model
         self.config = model.config
         self.use_custom_kv_cache = use_custom_kv_cache
         self.use_custom_sdpa = use_custom_sdpa
         self.disable_dynamic_shapes = disable_dynamic_shapes
-        self.metadata = save_config_to_constant_methods(model.config, model.generation_config)
+        self.metadata = save_config_to_constant_methods(
+            model.config, model.generation_config, get_max_seq_len=max_seq_len
+        )
         logging.info(f"Metadata to be recorded in PTE: {self.metadata}")
 
     def _prepare_export_inputs(self):
@@ -445,8 +449,6 @@ class CausalLMExportableModule(torch.nn.Module):
 
         exportable_module = TorchExportableModuleForDecoderOnlyLM(
             self.model,
-            batch_size=1,
-            max_cache_len=self.metadata.get("get_max_seq_len"),
         )
         self._register_custom_attention(exportable_module)
 
@@ -463,7 +465,9 @@ class CausalLMExportableModule(torch.nn.Module):
             )
 
         with torch.no_grad():
-            exported_program = exportable_module.export(input_ids, cache_position, dynamic_shapes, strict)
+            exported_program = exportable_module.export(
+                input_ids=input_ids, cache_position=cache_position, dynamic_shapes=dynamic_shapes, strict=strict
+            )
             # Apply RemoveTransposes pass to remove
             # any back-to-back transpose ops that are not needed
             # e.g. output of update_cache is transposed and
@@ -475,8 +479,11 @@ class CausalLMExportableModule(torch.nn.Module):
             mutated_gm = RemoveRedundantTransposes()(exported_program.module())[0]
             exported_program = torch.export.export(
                 mutated_gm,
-                args=(input_ids, cache_position),
-                kwargs={},
+                args=(),
+                kwargs={
+                    "input_ids": input_ids,
+                    "cache_position": cache_position,
+                },
                 dynamic_shapes=dynamic_shapes,
                 strict=strict,
             )

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -395,7 +395,7 @@ class CausalLMExportableModule(torch.nn.Module):
 
         exportable_module = TorchExportableModuleForDecoderOnlyLM(
             self.model,
-            max_batch_size=1,
+            batch_size=1,
             max_cache_len=self.metadata.get("get_max_seq_len"),
         )
         self._register_custom_attention(exportable_module)

--- a/optimum/exporters/executorch/tasks/causal_lm.py
+++ b/optimum/exporters/executorch/tasks/causal_lm.py
@@ -59,7 +59,8 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
     attn_implementation = kwargs.get("attn_implementation", "custom_sdpa" if use_custom_sdpa else "sdpa")
     cache_implementation = kwargs.get("cache_implementation", "static")
     use_custom_sdpa = use_custom_sdpa or attn_implementation == "custom_sdpa"
-    max_length = kwargs.get("max_length", 2048)
+    max_seq_len = kwargs.get("max_seq_len", None)
+    max_length = max_seq_len if max_seq_len is not None else kwargs.get("max_length", 2048)
     config = kwargs.get("config") or AutoConfig.from_pretrained(model_name_or_path)
 
     if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
@@ -135,4 +136,6 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
     qembedding_config = kwargs.get("qembedding", None)
     quantize_model_(eager_model, qlinear_config=qlinear_config, qembedding_config=qembedding_config)
 
-    return CausalLMExportableModule(eager_model, use_custom_kv_cache, use_custom_sdpa, disable_dynamic_shapes)
+    return CausalLMExportableModule(
+        eager_model, max_length, use_custom_kv_cache, use_custom_sdpa, disable_dynamic_shapes
+    )

--- a/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
+++ b/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
@@ -236,8 +236,8 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     return MultiModalTextToTextExportableModule(
         model=eager_model,
         modality="audio" if audio_encoder_name else "vision",
-        decoder_name=decoder_name,
         encoder_name=audio_encoder_name if audio_encoder_name else vision_encoder_name,
+        max_seq_len=max_length,
         processor_config=processor_config,
         use_custom_kv_cache=use_custom_kv_cache,
         use_custom_sdpa=use_custom_sdpa,

--- a/optimum/exporters/executorch/utils.py
+++ b/optimum/exporters/executorch/utils.py
@@ -54,7 +54,8 @@ def save_config_to_constant_methods(
         metadata.update(processor_config)
 
     # Combine/override with any additional kwargs and filter out None values
-    return {k: v for k, v in {**metadata, **kwargs}.items() if v is not None}
+    combined_metadata = {k: v for k, v in {**metadata, **kwargs}.items() if v is not None}
+    return combined_metadata
 
 
 def apply_chat_template_with_fallback(processor, conversation, **kwargs):

--- a/optimum/exporters/executorch/utils.py
+++ b/optimum/exporters/executorch/utils.py
@@ -33,7 +33,6 @@ def save_config_to_constant_methods(
         and isinstance(config.num_attention_heads, int)
     ):
         head_dim = config.hidden_size / config.num_attention_heads
-
     metadata = {
         "get_dtype": 5 if config.torch_dtype == torch.float16 else 6,
         "get_bos_id": getattr(config, "bos_token_id", None),
@@ -50,24 +49,11 @@ def save_config_to_constant_methods(
         "use_sdpa_with_kv_cache": "custom_sdpa" in config._attn_implementation,
     }
 
-    # Safely access fields from generation_config if it exists
-    if generation_config is not None:
-        # Check for cache_config and its attributes
-        cache_config = getattr(generation_config, "cache_config", None)
-        if cache_config is not None:
-            max_batch_size = cache_config.get("batch_size")
-            max_seq_len = cache_config.get("max_cache_len")
-
-            if max_batch_size is not None:
-                metadata["get_max_batch_size"] = max_batch_size
-            if max_seq_len is not None:
-                metadata["get_max_seq_len"] = max_seq_len
-
     # Include processor_config keys in metadata if provided
     if processor_config is not None:
         metadata.update(processor_config)
 
-    # Combine with any additional kwargs and filter out None values
+    # Combine/override with any additional kwargs and filter out None values
     return {k: v for k, v in {**metadata, **kwargs}.items() if v is not None}
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "optimum~=1.24",
     "executorch>=0.7.0",
-    "transformers==4.54.1",
+    "transformers==4.56.1",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
Some changes needed for the bump:
- Use early initialization to populate cache layer info - https://github.com/huggingface/transformers/pull/39797
- No more max seq length and batch size args in DecoderOnlyLM constructor
- Hybrid cache is getting deprecated, with static cache serving the same purpose with per-layer configs - https://github.com/huggingface/transformers/pull/40276