### PR TITLE
Modify image embedding return for Llava compatibility

### DIFF
--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -77,7 +77,12 @@ class VisionExportableModule(torch.nn.Module):
         input_features: torch.FloatTensor,
     ):
         image_embeds = self.model.get_image_features(input_features)
-        return image_embeds.unsqueeze(0)
+        # Hack, assuming the text decoder will take a 3D tensor (batch_size, seq_len, hidden_size)
+        if "llava" in self.model.config.name_or_path:
+            # Llava returns a list of 2D tensors (seq_len, hidden_size)
+            return image_embeds[0].unsqueeze(0)
+        else:
+            return image_embeds
 
 
 class AudioExportableModule(torch.nn.Module):

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -77,12 +77,9 @@ class VisionExportableModule(torch.nn.Module):
         input_features: torch.FloatTensor,
     ):
         image_embeds = self.model.get_image_features(input_features)
-        # Hack, assuming the text decoder will take a 3D tensor (batch_size, seq_len, hidden_size)
-        if "llava" in self.model.config.name_or_path:
-            # Llava returns a list of 2D tensors (seq_len, hidden_size)
-            return image_embeds[0].unsqueeze(0)
-        else:
-            return image_embeds
+        if isinstance(image_embeds, list):
+            image_embeds = torch.stack(image_embeds)
+        return image_embeds
 
 
 class AudioExportableModule(torch.nn.Module):


### PR DESCRIPTION
For `Gemma3` we don't need to unsqueeze the image embedding. For `Llava` we got a list of 2D tensors and here I'm assuming it only contains 1 tensor.

https://github.com/huggingface/transformers/blob/main/src/transformers/models/llava/modeling_llava.py#L214