### PR TITLE
Add unwrap_tensor_subclass to xnnpack

### DIFF
--- a/optimum/exporters/executorch/recipes/xnnpack.py
+++ b/optimum/exporters/executorch/recipes/xnnpack.py
@@ -17,6 +17,7 @@ from typing import Dict, Union
 
 from tabulate import tabulate
 from torch.export import ExportedProgram
+from torchao.utils import unwrap_tensor_subclass
 
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.devtools.backend_debug import get_delegation_info
@@ -104,6 +105,7 @@ def export_to_executorch_with_xnnpack(
             )
         return {pte_name: et_prog}
 
+    model = unwrap_tensor_subclass(model)
     exported_progs = model.export()
 
     if (


### PR DESCRIPTION
This PR adds unwrap_tensor_subclass to the XNNPACK recipe.

unwrap_tensor_subclass is already called during quantization, but if you export a pre-quantized checkpoint from HF, you don't go through the quantization APIs, and unwrap_tensor_subclass is never called.