### PR TITLE
Add SmolVLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ We currently support a wide range of popular transformer models, including encod
 - [Roberta](https://huggingface.co/FacebookAI/xlm-roberta-base): FacebookAI's `xlm-roberta-base` and its variants
 
 ### Vision Models
+- 💡[**NEW**] [SmolVLM](HuggingFaceTB/SmolVLM-Instruct): `SmolVLM`  and it's variants (256M, 500M, and 2B)
+- 💡[**NEW**] [Gemma3 4B](https://huggingface.co/google/gemma-3-4b-it): `gemma-3-4b-it` 
 - [Cvt](https://huggingface.co/microsoft/cvt-13): Convolutional Vision Transformer
 - [Deit](https://huggingface.co/facebook/deit-base-distilled-patch16-224): Distilled Data-efficient Image Transformer (base-sized)
 - [Dit](https://huggingface.co/microsoft/dit-base-finetuned-rvlcdip): Document Image Transformer (base-sized)

--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -1346,8 +1346,8 @@ class ExecuTorchModelForMultiModalToText(ExecuTorchModelBase):
 
         # Sanity check
         if self.tokenizer.bos_token_id is not None and self.tokenizer.bos_token_id != self.bos_token_id:
-            raise ValueError(
-                f"The tokenizer's bos_token_id={self.tokenizer.bos_token_id} must be the same as the model's bos_token_id={self.bos_token_id}."
+            logging.warning(
+                f"The tokenizer's bos_token_id={self.tokenizer.bos_token_id} is not the same as the model's bos_token_id={self.bos_token_id}."
             )
         if isinstance(self.tokenizer, PreTrainedTokenizer) and not verify_eos_tokens_in_pretrained_tokenizer(
             self.eos_token_id, self.tokenizer

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -37,11 +37,55 @@ from optimum.executorch.attentions.custom_sdpa import get_custom_sdpa_for_ring_k
 
 from .utils import apply_chat_template_with_fallback, process_conversation_inputs, save_config_to_constant_methods
 
+def _patch_idefics3_vision_embeddings_for_export(vision_model):
+    """
+    Patch Idefics3VisionEmbeddings to make it export-friendly by removing data-dependent operations.
+    This assumes batch_size=1 and a full attention mask (all 1s).
+    """
+    import types
+
+    def export_friendly_forward(self, pixel_values: torch.FloatTensor, patch_attention_mask: torch.BoolTensor) -> torch.Tensor:
+        batch_size, _, max_im_h, max_im_w = pixel_values.shape
+
+        patch_embeds = self.patch_embedding(pixel_values)
+        embeddings = patch_embeds.flatten(2).transpose(1, 2)
+
+        nb_patches_h = max_im_h // self.patch_size
+        nb_patches_w = max_im_w // self.patch_size
+        N = self.num_patches_per_side
+
+        # For export, we assume full attention mask and compute position IDs statically.
+        # This avoids the data-dependent loop over batch dimension.
+        h_indices = torch.arange(nb_patches_h, device=pixel_values.device, dtype=torch.long)
+        w_indices = torch.arange(nb_patches_w, device=pixel_values.device, dtype=torch.long)
+
+        # This replaces bucketize(x, boundaries=[1/N, 2/N, ...], right=True) ≈ floor(x * N), which
+        # we don't have a kernel for at the moment.
+        bucket_coords_h = (h_indices * N) // nb_patches_h
+        bucket_coords_w = (w_indices * N) // nb_patches_w
+
+        bucket_coords_h = torch.clamp(bucket_coords_h, max=N - 1)
+        bucket_coords_w = torch.clamp(bucket_coords_w, max=N - 1)
+
+        pos_ids = (bucket_coords_h[:, None] * N + bucket_coords_w[None, :]).reshape(-1)
+        position_ids = pos_ids.unsqueeze(0).expand(batch_size, -1)
+        embeddings = embeddings + self.position_embedding(position_ids)
+        return embeddings
+
+    # Patch the forward method.
+    vision_model.embeddings.forward = types.MethodType(export_friendly_forward, vision_model.embeddings)
+
 
 class VisionExportableModule(torch.nn.Module):
     def __init__(self, model: torch.nn.Module):
         super().__init__()
         self.model = model
+
+        # Patch Idefics3 vision embeddings if needed
+        if hasattr(model, 'model') and hasattr(model.model, 'vision_model'):
+            model_type = getattr(model.config, 'model_type', '')
+            if 'idefics3' in model_type.lower():
+                _patch_idefics3_vision_embeddings_for_export(model.model.vision_model)
 
     def prepare_export_inputs(self):
         # 1. Get export inputs
@@ -61,13 +105,6 @@ class VisionExportableModule(torch.nn.Module):
             tokenizer,
             sample_conversation_with_image,
         )
-        # processed_inputs = processor.apply_chat_template(
-        #     sample_conversation_with_image,
-        #     add_generation_prompt=True,
-        #     tokenize=True,
-        #     return_dict=True,
-        #     return_tensors="pt",
-        # )
         if "pixel_values" not in processed_inputs:
             raise ValueError(
                 f"Unable to obtain sample audio encoder inputs for export for {model_id} - the processor did not return formatted inputs with the 'pixel_values' key: {processed_inputs}"
@@ -83,7 +120,9 @@ class VisionExportableModule(torch.nn.Module):
         self,
         input_features: torch.FloatTensor,
     ):
-        image_embeds = self.model.get_image_features(input_features)
+        # Pass pixel_attention_mask=None to avoid data-dependent operations during export.
+        # The model will create a mask full of 1s internally if None is passed.
+        image_embeds = self.model.get_image_features(input_features, pixel_attention_mask=None)
         if isinstance(image_embeds, list):
             image_embeds = torch.stack(image_embeds)
         return image_embeds

--- a/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
+++ b/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
@@ -151,6 +151,13 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     if not (hasattr(config, "text_config")):
         raise ValueError(f"The model {model_name_or_path} does not have a `text_config`.")
 
+    config.use_export_friendly = True
+    config.text_config.use_export_friendly = True
+    if hasattr(config, "audio_config"):
+        config.audio_config.use_export_friendly = True
+    if hasattr(config, "vision_config"):
+        config.vision_config.use_export_friendly = True
+
     if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
         # NOTE: Avoid hitting the data-dependent control flow in _longrope_frequency_update.
         config.rope_scaling["type"] = "default"

--- a/tests/models/test_modeling_smolvlm.py
+++ b/tests/models/test_modeling_smolvlm.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import logging
+import os
+import sys
+import unittest
+
+import pytest
+from transformers import AutoProcessor, AutoTokenizer
+from transformers.testing_utils import slow
+
+from optimum.executorch import ExecuTorchModelForMultiModalToText
+
+from ..utils import check_multimodal_output_quality
+
+
+is_linux_ci = sys.platform.startswith("linux") and os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+
+class ExecuTorchModelIntegrationTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @slow
+    @pytest.mark.run_slow
+    @pytest.mark.skipif(is_linux_ci, reason="OOM")
+    def test_smolvlm_with_custom_sdpa_kv_cache_8da4w_8we(self):
+        model_id = "HuggingFaceTB/SmolVLM-Instruct"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        processor = AutoProcessor.from_pretrained(model_id)
+        conversation = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg",
+                    },
+                    {"type": "text", "text": "Can you describe this image?"},
+                ],
+            },
+        ]
+
+        model = ExecuTorchModelForMultiModalToText.from_pretrained(
+            # model_id,
+            "/home/jackzhxng/models/smolvlm",
+            recipe="xnnpack",
+            task="multimodal-text-to-text",
+            use_custom_sdpa=True,
+            use_custom_kv_cache=True,
+            qlinear="8da4w",
+            qlinear_group_size=32,
+            # Can't quantize the encoder a the moment, hidden dim of 4304 doesn't fit ExecuTorch's
+            # XNNPack 32-group size quantized kernels. See https://github.com/pytorch/executorch/issues/14221.
+            qembedding_config="8w",
+        )
+
+        # Generate
+        generated_text = model.text_generation(
+            processor=processor,
+            tokenizer=tokenizer,
+            input_conversation=conversation,
+            max_seq_len=64,
+        )
+        logging.info(f"\nGenerated text:\n\t{generated_text}")
+        generated_tokens = tokenizer(generated_text, return_tensors="pt").input_ids
+        breakpoint()
+
+        del model
+        del tokenizer
+        gc.collect()
+
+        # Should be something like: 'Okay, let's analyze this image and discuss potential
+        # cautions for visiting this location. Based on the picture, we're looking at a
+        # serene lake scene with mountains in the background, a wooden pier extending into
+        # the water, and a generally calm atmosphere.'
+        self.assertTrue("Statue" in generated_text)
+        self.assertTrue("Liberty" in generated_text)
+        self.assertTrue(
+            check_multimodal_output_quality(model_id, generated_tokens, conversation, max_perplexity_threshold=5)
+        )


### PR DESCRIPTION
```
 The image depicts a clear and vivid view of a cityscape with a prominent focus on the Statue of Liberty in the foreground. The Statue of Liberty is centrally positioned and prominently displayed, standing on a small, rocky platform that extends into the water. The water in the background is a deep blue, with a few
 ships visible
⚠️ DISCLAIMER: Pythoi-based perf measurements are approximate and may not match absolute speeds on Android/iOS apps. They are intended for relative comparisons——e.g. SDPA vs. custom SDPA, FP16 vs. FP32——so you can gauge performance improvements from each optimization step. For end-to-end, platform-accurate benchmar
ks, please use the official ExecuTorch apps:
  • iOS:     https://github.com/pytorch/executorch/tree/main/extension/benchmark/apple/Benchmark
  • Android: https://github.com/pytorch/executorch/tree/main/extension/benchmark/android/benchmark

PyTorchObserver {"prompt_tokens": 1197, "generated_tokens": 64, "model_load_start_ms": 0, "model_load_end_ms": 0, "inference_start_ms": 1760545277225, "token_encode_end_ms": 1760545277506, "model_execution_start_ms": 0, "model_execution_end_ms": 0, "inference_end_ms": 1760545314593, "prompt_eval_end_ms": 1760545308
404, "first_token_ms": 1760545308515, "aggregate_sampling_time_ms": 37068, "SCALING_FACTOR_UNITS_PER_SECOND": 1000}
        Prompt Tokens: 1197 Generated Tokens: 64
        Model Load Time:                0.000000 (seconds)
        Total inference time:           37.368000 (seconds)              Rate:  1.712695 (tokens/second)
                Prompt evaluation:      31.179000 (seconds)              Rate:  38.391225 (tokens/second)
                Generated 64 tokens:    6.189000 (seconds)               Rate:  10.340927 (tokens/second)
        Time to first generated token:  31.290000 (seconds)
        Sampling time over 1261 tokens: 37.068000 (seconds)

INFO     root:utils.py:87 Starting perplexity check with multimodal model 'HuggingFaceTB/SmolVLM-Instruct' ...
Fetching 2 files: 100%|███████████████████████████████████████████████████| 2/2 [00:00<00:00, 5349.88it/s]
INFO     root:utils.py:135 ✓ Perplexity check passed: 2.84 <= 5
PASSED
```

Requires the following Transformers changes (also WIP) - https://github.com/huggingface/transformers/pull/41629