### PR TITLE
Fix missing entry points in pyproject.toml for optimum-cli export executorch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/huggingface/optimum-executorch"
 
+[project.entry-points."optimum.commands.register"]
+executorch = "optimum.commands.register.register_export:REGISTER_COMMANDS"
+
 # ---- setuptools config ----
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary

Fixes the `optimum-cli export executorch` command not being recognized after editable installation.

When installing `optimum-executorch` in editable mode, users encountered:

```
optimum-cli export: error: argument {onnx,tflite}: invalid choice: 'executorch' (choose from 'onnx', 'tflite')
```


## Root Cause

The `pyproject.toml` was missing the entry points configuration required for `optimum` to discover and register the `executorch` export subcommand. While the registration code existed in `optimum/commands/register/register_export.py`, it was never wired up via the package's entry points.

## Changes

Added the missing entry points configuration to `pyproject.toml`:

```toml
[project.entry-points."optimum.commands.register"]
executorch = "optimum.commands.register.register_export:REGISTER_COMMANDS"
```


This enables optimum-cli to discover and load the ExecuTorchExportCommand during startup.


## Testing
Verified the entry point is properly registered after reinstallation:
```
from importlib.metadata import entry_points
eps = entry_points()
print([ep for ep in eps.get('optimum.commands.register', [])])
# Output: [EntryPoint(name='executorch', value='optimum.commands.register.register_export:REGISTER_COMMANDS', group='optimum.commands.register')]
```