### PR TITLE
Fix broken error handling for unregistered task/recipe lookup

### DIFF
--- a/optimum/exporters/executorch/__main__.py
+++ b/optimum/exporters/executorch/__main__.py
@@ -119,10 +119,11 @@ def main_export(
     discover_tasks()
 
     # Load the model for specific task
-    try:
-        task_func = task_registry.get(task)
-    except KeyError as e:
-        raise RuntimeError(f"The task '{task}' isn't registered. Detailed error: {e}")
+    if task not in task_registry:
+        raise RuntimeError(
+            f"The task '{task}' isn't registered. Available tasks: {list(task_registry.keys())}"
+        )
+    task_func = task_registry[task]
 
     kwargs["cache_dir"] = cache_dir
     kwargs["trust_remote_code"] = trust_remote_code

--- a/optimum/exporters/executorch/convert.py
+++ b/optimum/exporters/executorch/convert.py
@@ -71,10 +71,11 @@ def export_to_executorch(
     discover_recipes()
 
     # Export and lower the model to ExecuTorch with the recipe
-    try:
-        recipe_func = recipe_registry.get(recipe)
-    except KeyError as e:
-        raise RuntimeError(f"The recipe '{recipe}' isn't registered. Detailed error: {e}")
+    if recipe not in recipe_registry:
+        raise RuntimeError(
+            f"The recipe '{recipe}' isn't registered. Available recipes: {list(recipe_registry.keys())}"
+        )
+    recipe_func = recipe_registry[recipe]
 
     executorch_progs = recipe_func(model, **kwargs)
 


### PR DESCRIPTION
`dict.get()` returns `None` on missing keys instead of raising `KeyError`, making the `except KeyError` block dead code. An invalid task or recipe would fall through as `None` and later crash with an unhelpful `TypeError: 'NoneType' object is not callable`.

Replace with an explicit membership check that surfaces the available task/recipe names in the error message.