### PR TITLE
Fix crash after failed audio download in process_conversation_inputs

### DIFF
--- a/optimum/exporters/executorch/utils.py
+++ b/optimum/exporters/executorch/utils.py
@@ -174,11 +174,11 @@ def process_conversation_inputs(
 
         # Download and process audio
         try:
-            resp = requests.get(audio_path)
+            resp = requests.get(audio_path, timeout=30)
             resp.raise_for_status()
             buf = io.BytesIO(resp.content)
-        except requests.exceptions.RequestException:
-            print("Could not download input audio file.")
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"Could not download input audio file from '{audio_path}': {e}") from e
 
         wav, sampling_rate = torchaudio.load(buf, normalize=True)
         if wav.shape[0] != 1:


### PR DESCRIPTION
The except block printed an error but let execution fall through to torchaudio.load(buf) where buf was undefined, causing an UnboundLocalError. Re-raise as RuntimeError with the URL and cause. Also add timeout=30 to requests.get() to prevent indefinite hangs.