### PR TITLE
Expose --qparams_algorithm CLI arg for quantization parameter selection

### DIFF
--- a/optimum/commands/export/executorch.py
+++ b/optimum/commands/export/executorch.py
@@ -180,6 +180,13 @@ def parse_args_executorch(parser):
         help="Group size for encoder embedding quantization, for model architectures with an encoder.",
     )
     required_group.add_argument(
+        "--qparams_algorithm",
+        type=str,
+        choices=["affine", "hqq_scale_only"],
+        required=False,
+        help="Algorithm for choosing quantization parameters. Default: hqq_scale_only.",
+    )
+    required_group.add_argument(
         "--max_seq_len",
         type=int,
         required=False,
@@ -273,6 +280,8 @@ class ExecuTorchExportCommand(BaseOptimumCLICommand):
             kwargs["qembedding_encoder"] = self.args.qembedding_encoder
         if self.args.qembedding_encoder_group_size:
             kwargs["qembedding_encoder_group_size"] = self.args.qembedding_encoder_group_size
+        if self.args.qparams_algorithm:
+            kwargs["qparams_algorithm"] = self.args.qparams_algorithm
         if self.args.max_seq_len:
             kwargs["max_seq_len"] = self.args.max_seq_len
         if hasattr(self.args, "dtype") and self.args.dtype:

--- a/optimum/exporters/executorch/tasks/asr.py
+++ b/optimum/exporters/executorch/tasks/asr.py
@@ -65,11 +65,13 @@ def load_seq2seq_speech_model(model_name_or_path: str, **kwargs) -> Seq2SeqLMExp
     qlinear_encoder_packing_format = kwargs.get("qlinear_encoder_packing_format", None)
     qembedding_config = kwargs.get("qembedding", None)
     qembedding_group_size = kwargs.get("qembedding_group_size", None)
+    qparams_algorithm = kwargs.get("qparams_algorithm", None)
 
     # Quantize decoder linear weights.
     quantize_decoder_kwargs = {
         "eager_model": getattr(full_model.model, "decoder"),
         "qlinear_config": qlinear_config,
+        "qparams_algorithm": qparams_algorithm,
     }
     if qlinear_group_size is not None:
         quantize_decoder_kwargs["qlinear_group_size"] = qlinear_group_size
@@ -81,6 +83,7 @@ def load_seq2seq_speech_model(model_name_or_path: str, **kwargs) -> Seq2SeqLMExp
     quantize_encoder_kwargs = {
         "eager_model": getattr(full_model.model, "encoder"),
         "qlinear_config": qlinear_encoder_config,
+        "qparams_algorithm": qparams_algorithm,
     }
     if qlinear_encoder_group_size is not None:
         quantize_encoder_kwargs["qlinear_group_size"] = qlinear_encoder_group_size
@@ -92,6 +95,7 @@ def load_seq2seq_speech_model(model_name_or_path: str, **kwargs) -> Seq2SeqLMExp
     quantize_decoder_embedding_kwargs = {
         "eager_model": full_model,
         "qembedding_config": qembedding_config,
+        "qparams_algorithm": qparams_algorithm,
     }
     if qembedding_group_size is not None:
         quantize_decoder_embedding_kwargs["qembedding_group_size"] = qembedding_group_size

--- a/optimum/exporters/executorch/tasks/causal_lm.py
+++ b/optimum/exporters/executorch/tasks/causal_lm.py
@@ -147,11 +147,13 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
     qlinear_config = kwargs.get("qlinear", None)
     qlinear_packing_format = kwargs.get("qlinear_packing_format", None)
     qembedding_config = kwargs.get("qembedding", None)
+    qparams_algorithm = kwargs.get("qparams_algorithm", None)
     quantize_model_(
         eager_model,
         qlinear_config=qlinear_config,
         qlinear_packing_format=qlinear_packing_format,
         qembedding_config=qembedding_config,
+        qparams_algorithm=qparams_algorithm,
     )
 
     return CausalLMExportableModule(

--- a/optimum/exporters/executorch/tasks/masked_lm.py
+++ b/optimum/exporters/executorch/tasks/masked_lm.py
@@ -44,11 +44,13 @@ def load_masked_lm_model(model_name_or_path: str, **kwargs) -> MaskedLMExportabl
     qlinear_config = kwargs.get("qlinear", None)
     qlinear_packing_format = kwargs.get("qlinear_packing_format", None)
     qembedding_config = kwargs.get("qembedding", None)
+    qparams_algorithm = kwargs.get("qparams_algorithm", None)
     quantize_model_(
         eager_model,
         qlinear_config=qlinear_config,
         qlinear_packing_format=qlinear_packing_format,
         qembedding_config=qembedding_config,
+        qparams_algorithm=qparams_algorithm,
     )
 
     return MaskedLMExportableModule(eager_model)

--- a/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
+++ b/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
@@ -152,6 +152,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     qembedding_group_size = kwargs.get("qembedding_group_size", None)
     qembedding_encoder_config = kwargs.get("qembedding_encoder", None)
     qembedding_encoder_group_size = kwargs.get("qembedding_encoder_group_size", None)
+    qparams_algorithm = kwargs.get("qparams_algorithm", None)
 
     # Quantize decoder linear weights.
     if qlinear_config:
@@ -159,6 +160,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_decoder_kwargs = {
         "eager_model": eager_model.get_decoder(),
         "qlinear_config": qlinear_config,
+        "qparams_algorithm": qparams_algorithm,
     }
     if qlinear_group_size is not None:
         quantize_decoder_kwargs["qlinear_group_size"] = qlinear_group_size
@@ -182,6 +184,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
         quantize_lm_head_kwargs = {
             "eager_model": lm_head,
             "qlinear_config": qlinear_config,
+            "qparams_algorithm": qparams_algorithm,
         }
         quantize_model_(**quantize_lm_head_kwargs)
 
@@ -191,6 +194,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_encoder_kwargs = {
         "eager_model": eager_encoder,
         "qlinear_config": qlinear_encoder_config,
+        "qparams_algorithm": qparams_algorithm,
     }
     if qlinear_encoder_group_size is not None:
         quantize_encoder_kwargs["qlinear_group_size"] = qlinear_encoder_group_size
@@ -204,6 +208,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_decoder_embedding_kwargs = {
         "eager_model": eager_model.get_decoder(),
         "qembedding_config": qembedding_config,
+        "qparams_algorithm": qparams_algorithm,
     }
     if qembedding_group_size is not None:
         quantize_decoder_embedding_kwargs["qembedding_group_size"] = qembedding_group_size
@@ -215,6 +220,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_encoder_embedding_kwargs = {
         "eager_model": eager_encoder,
         "qembedding_config": qembedding_encoder_config,
+        "qparams_algorithm": qparams_algorithm,
     }
     if qembedding_encoder_group_size is not None:
         quantize_encoder_embedding_kwargs["qembedding_group_size"] = qembedding_encoder_group_size


### PR DESCRIPTION
Fixes #226

## Problem
`quantize_model_()` accepts a `qparams_algorithm` parameter, but there is no CLI argument to pass it through. Users cannot control which algorithm is used for computing quantization parameters during export.

## Changes
- Add `--qparams_algorithm` CLI argument (`choices=["affine", "hqq_scale_only"]`)
- Wire it through all task loaders (`causal_lm`, `masked_lm`, `asr`, `multimodal_text_to_text`) to `quantize_model_()`

## Usage
```
optimum-cli export executorch \
   --model google/gemma-3-1b-it \
   --task text-generation --recipe xnnpack \
   --qlinear 8da4w --qparams_algorithm affine \
   --output_dir output/
```

No behavior change when `--qparams_algorithm` is not specified.