### PR TITLE
Expose --quantize_dtype CLI arg to control dtype during quantization

### DIFF
--- a/optimum/commands/export/executorch.py
+++ b/optimum/commands/export/executorch.py
@@ -180,6 +180,13 @@ def parse_args_executorch(parser):
         help="Group size for encoder embedding quantization, for model architectures with an encoder.",
     )
     required_group.add_argument(
+        "--quantize_dtype",
+        type=str,
+        choices=["float32", "float16", "bfloat16"],
+        required=False,
+        help="Dtype to use during quantization. Useful when the quantization dtype should differ from --dtype, e.g. to match QAT training precision.",
+    )
+    required_group.add_argument(
         "--max_seq_len",
         type=int,
         required=False,
@@ -273,6 +280,8 @@ class ExecuTorchExportCommand(BaseOptimumCLICommand):
             kwargs["qembedding_encoder"] = self.args.qembedding_encoder
         if self.args.qembedding_encoder_group_size:
             kwargs["qembedding_encoder_group_size"] = self.args.qembedding_encoder_group_size
+        if self.args.quantize_dtype:
+            kwargs["quantize_dtype"] = self.args.quantize_dtype
         if self.args.max_seq_len:
             kwargs["max_seq_len"] = self.args.max_seq_len
         if hasattr(self.args, "dtype") and self.args.dtype:

--- a/optimum/exporters/executorch/quantization.py
+++ b/optimum/exporters/executorch/quantization.py
@@ -31,6 +31,7 @@ def quantize_model_(
     qembedding_config: Optional[str] = None,
     qembedding_group_size: Optional[int] = 0,
     qparams_algorithm: Optional[str] = None,
+    quantize_dtype: Optional[str] = None,
 ) -> torch.nn.Module:
     # qparams_algorithm is applied to IntxWeightOnlyConfig and Int8DynamicActivationIntxWeightConfig.
     # Not applied to Int4WeightOnlyConfig (different API) or UIntxWeightOnlyConfig (no such param).
@@ -38,6 +39,11 @@ def quantize_model_(
         qparams_algorithm = DEFAULT_QPARAMS_ALGORITHM
     if not (qlinear_config or qembedding_config):
         return
+
+    original_dtype = None
+    if quantize_dtype is not None:
+        original_dtype = next(eager_model.parameters()).dtype
+        eager_model.to(dtype=getattr(torch, quantize_dtype))
 
     from torchao.quantization.granularity import PerAxis, PerGroup
     from torchao.quantization.quant_api import (
@@ -187,4 +193,6 @@ def quantize_model_(
                 filter_fn=per_token_filter,
             )
 
+    if original_dtype is not None:
+        eager_model.to(dtype=original_dtype)
     unwrap_tensor_subclass(eager_model)

--- a/optimum/exporters/executorch/tasks/asr.py
+++ b/optimum/exporters/executorch/tasks/asr.py
@@ -65,11 +65,13 @@ def load_seq2seq_speech_model(model_name_or_path: str, **kwargs) -> Seq2SeqLMExp
     qlinear_encoder_packing_format = kwargs.get("qlinear_encoder_packing_format", None)
     qembedding_config = kwargs.get("qembedding", None)
     qembedding_group_size = kwargs.get("qembedding_group_size", None)
+    quantize_dtype = kwargs.get("quantize_dtype", None)
 
     # Quantize decoder linear weights.
     quantize_decoder_kwargs = {
         "eager_model": getattr(full_model.model, "decoder"),
         "qlinear_config": qlinear_config,
+        "quantize_dtype": quantize_dtype,
     }
     if qlinear_group_size is not None:
         quantize_decoder_kwargs["qlinear_group_size"] = qlinear_group_size
@@ -81,6 +83,7 @@ def load_seq2seq_speech_model(model_name_or_path: str, **kwargs) -> Seq2SeqLMExp
     quantize_encoder_kwargs = {
         "eager_model": getattr(full_model.model, "encoder"),
         "qlinear_config": qlinear_encoder_config,
+        "quantize_dtype": quantize_dtype,
     }
     if qlinear_encoder_group_size is not None:
         quantize_encoder_kwargs["qlinear_group_size"] = qlinear_encoder_group_size
@@ -92,6 +95,7 @@ def load_seq2seq_speech_model(model_name_or_path: str, **kwargs) -> Seq2SeqLMExp
     quantize_decoder_embedding_kwargs = {
         "eager_model": full_model,
         "qembedding_config": qembedding_config,
+        "quantize_dtype": quantize_dtype,
     }
     if qembedding_group_size is not None:
         quantize_decoder_embedding_kwargs["qembedding_group_size"] = qembedding_group_size

--- a/optimum/exporters/executorch/tasks/causal_lm.py
+++ b/optimum/exporters/executorch/tasks/causal_lm.py
@@ -147,11 +147,13 @@ def load_causal_lm_model(model_name_or_path: str, **kwargs) -> CausalLMExportabl
     qlinear_config = kwargs.get("qlinear", None)
     qlinear_packing_format = kwargs.get("qlinear_packing_format", None)
     qembedding_config = kwargs.get("qembedding", None)
+    quantize_dtype = kwargs.get("quantize_dtype", None)
     quantize_model_(
         eager_model,
         qlinear_config=qlinear_config,
         qlinear_packing_format=qlinear_packing_format,
         qembedding_config=qembedding_config,
+        quantize_dtype=quantize_dtype,
     )
 
     return CausalLMExportableModule(

--- a/optimum/exporters/executorch/tasks/masked_lm.py
+++ b/optimum/exporters/executorch/tasks/masked_lm.py
@@ -44,11 +44,13 @@ def load_masked_lm_model(model_name_or_path: str, **kwargs) -> MaskedLMExportabl
     qlinear_config = kwargs.get("qlinear", None)
     qlinear_packing_format = kwargs.get("qlinear_packing_format", None)
     qembedding_config = kwargs.get("qembedding", None)
+    quantize_dtype = kwargs.get("quantize_dtype", None)
     quantize_model_(
         eager_model,
         qlinear_config=qlinear_config,
         qlinear_packing_format=qlinear_packing_format,
         qembedding_config=qembedding_config,
+        quantize_dtype=quantize_dtype,
     )
 
     return MaskedLMExportableModule(eager_model)

--- a/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
+++ b/optimum/exporters/executorch/tasks/multimodal_text_to_text.py
@@ -152,6 +152,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     qembedding_group_size = kwargs.get("qembedding_group_size", None)
     qembedding_encoder_config = kwargs.get("qembedding_encoder", None)
     qembedding_encoder_group_size = kwargs.get("qembedding_encoder_group_size", None)
+    quantize_dtype = kwargs.get("quantize_dtype", None)
 
     # Quantize decoder linear weights.
     if qlinear_config:
@@ -159,6 +160,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_decoder_kwargs = {
         "eager_model": eager_model.get_decoder(),
         "qlinear_config": qlinear_config,
+        "quantize_dtype": quantize_dtype,
     }
     if qlinear_group_size is not None:
         quantize_decoder_kwargs["qlinear_group_size"] = qlinear_group_size
@@ -182,6 +184,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
         quantize_lm_head_kwargs = {
             "eager_model": lm_head,
             "qlinear_config": qlinear_config,
+            "quantize_dtype": quantize_dtype,
         }
         quantize_model_(**quantize_lm_head_kwargs)
 
@@ -191,6 +194,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_encoder_kwargs = {
         "eager_model": eager_encoder,
         "qlinear_config": qlinear_encoder_config,
+        "quantize_dtype": quantize_dtype,
     }
     if qlinear_encoder_group_size is not None:
         quantize_encoder_kwargs["qlinear_group_size"] = qlinear_encoder_group_size
@@ -204,6 +208,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_decoder_embedding_kwargs = {
         "eager_model": eager_model.get_decoder(),
         "qembedding_config": qembedding_config,
+        "quantize_dtype": quantize_dtype,
     }
     if qembedding_group_size is not None:
         quantize_decoder_embedding_kwargs["qembedding_group_size"] = qembedding_group_size
@@ -215,6 +220,7 @@ def load_multimodal_text_to_text_model(model_name_or_path: str, **kwargs):
     quantize_encoder_embedding_kwargs = {
         "eager_model": eager_encoder,
         "qembedding_config": qembedding_encoder_config,
+        "quantize_dtype": quantize_dtype,
     }
     if qembedding_encoder_group_size is not None:
         quantize_encoder_embedding_kwargs["qembedding_group_size"] = qembedding_encoder_group_size


### PR DESCRIPTION
Fixes #226

## Problem
The model is loaded in `--dtype` before quantization. There is no way to quantize in a different dtype (e.g. to match QAT training precision).

## Changes
- Add `--quantize_dtype` CLI argument (`choices=["float32", "float16", "bfloat16"]`)
- Wire it through all task loaders (`causal_lm`, `masked_lm`, `asr`, `multimodal_text_to_text`) to `quantize_model_()`
- In `quantize_model_()`: cast to `quantize_dtype` before quantization, restore original dtype before `unwrap_tensor_subclass`

The restore-before-unwrap ordering matters: `unwrap_tensor_subclass` breaks `.to()` for quantized tensor subclasses, so the dtype cast must happen while the subclass wrappers are still intact.

## Usage
```
optimum-cli export executorch \
   --model merged-qat-model/ \
   --task text-generation --recipe xnnpack \
   --qlinear 8da4w --quantize_dtype bfloat16 \
   --dtype float32 \
   --output_dir output/
```

No behavior change when `--quantize_dtype` is not specified.