### PR TITLE
Allow f16/bf16 in custom SDPA

### DIFF
--- a/optimum/executorch/attentions/custom_kv_cache.py
+++ b/optimum/executorch/attentions/custom_kv_cache.py
@@ -174,7 +174,7 @@ class ETCustomStaticCache(StaticCache):
             dtype = legacy_cache.k_cache.dtype
 
         # assert device is None or device == "cpu"
-        assert dtype is None or dtype == torch.float32
+        assert dtype is None or dtype in (torch.float32, torch.bfloat16, torch.float16)
 
         # Use the legacy cache's max_seq_len if max_cache_len is not specified
         if max_cache_len is None and hasattr(legacy_cache, "max_seq_len"):

--- a/optimum/executorch/attentions/custom_sdpa.py
+++ b/optimum/executorch/attentions/custom_sdpa.py
@@ -81,11 +81,7 @@ def custom_sdpa_with_start_pos_forward(
     key = key.transpose(1, 2)
     value = value.transpose(1, 2)
 
-    # Convert the hell out of the inputs to fp32 and back
     input_dtype = query.dtype
-    query = query.to(torch.float32)
-    key = key.to(torch.float32)
-    value = value.to(torch.float32)
 
     # Ignore the causal flag from kwargs but use the one in module
     kwargs.pop("is_causal", None)


### PR DESCRIPTION
The current module swapped SDPA always runs SDPA in f32, up-converting activations if necessary. We now have native support for half-precision SDPA in ET, so relax the assertions and remove the casts.