### PR TITLE
Add optional ETRecord generation/saving for the xnnpack recipe

### DIFF
--- a/optimum/exporters/executorch/convert.py
+++ b/optimum/exporters/executorch/convert.py
@@ -55,7 +55,10 @@ def export_to_executorch(
         output_dir (`Union[str, Path]`):
             Path to the directory where the resulting ExecuTorch model will be saved.
         **kwargs:
-            Additional configuration options passed to the recipe.
+            Additional configuration options passed to the recipe. Notably `generate_etrecord`
+            (`bool`, defaults to `False`): if `True`, saves an ETRecord (`{name}_etrecord.bin`) alongside
+            the `.pte` file for use with the ExecuTorch Inspector. Currently only honored by the
+            `xnnpack` recipe; other recipes ignore the flag and no ETRecord is produced.
 
     Returns:
         `ExecuTorchProgram`:
@@ -66,6 +69,9 @@ def export_to_executorch(
         - The exported model is stored in the specified output directory with the fixed filename `model.pte`.
         - The resulting ExecuTorch program is serialized and saved to the output directory.
     """
+
+    # Extract generate_etrecord from kwargs (default: False to avoid unwanted files)
+    generate_etrecord = kwargs.get("generate_etrecord", False)
 
     # Dynamically discover and import registered recipes
     discover_recipes()
@@ -86,5 +92,26 @@ def export_to_executorch(
                 f"Saved exported program to {full_path} ({os.path.getsize(full_path) / (1024 * 1024):.2f} MB)"
             )
         prog.write_tensor_data_to_file(output_dir)
+
+        # Save ETRecord only if explicitly requested
+        if generate_etrecord:
+            try:
+                etrecord = prog.get_etrecord()
+            except RuntimeError:
+                # Raised when the recipe didn't generate an ETRecord (e.g. only the xnnpack
+                # recipe currently forwards generate_etrecord to the lowering pipeline).
+                logging.warning(
+                    f"generate_etrecord=True was requested but no ETRecord was produced for {name}; "
+                    "the selected recipe may not support ETRecord generation yet."
+                )
+            else:
+                etrecord_path = os.path.join(output_dir, f"{name}_etrecord.bin")
+                try:
+                    etrecord.save(etrecord_path)
+                except Exception as e:
+                    logging.warning(f"Failed to save ETRecord for {name}: {e}")
+                else:
+                    etrecord_size_kb = os.path.getsize(etrecord_path) / 1024
+                    logging.info(f"Saved ETRecord to {etrecord_path} ({etrecord_size_kb:.2f} KB)")
 
     return executorch_progs

--- a/optimum/exporters/executorch/recipes/xnnpack.py
+++ b/optimum/exporters/executorch/recipes/xnnpack.py
@@ -61,6 +61,8 @@ def export_to_executorch_with_xnnpack(
             The PyTorch model to be exported to ExecuTorch.
         **kwargs:
             Additional keyword arguments for recipe-specific configurations, e.g. export using different example inputs, or different compile/bechend configs.
+            `generate_etrecord` (`bool`, defaults to `False`): if `True`, generates an ETRecord during
+            lowering so `convert.py` can save it alongside the `.pte` file.
 
     Returns:
         Dict[str, ExecutorchProgram]:
@@ -92,6 +94,7 @@ def export_to_executorch_with_xnnpack(
             ),
             constant_methods=metadata,
             transform_passes=[RemovePaddingIdxEmbeddingPass()],
+            generate_etrecord=kwargs.get("generate_etrecord", False),
         )
         et_prog = et_prog.to_executorch(
             config=ExecutorchBackendConfig(**backend_config_dict),


### PR DESCRIPTION

## Summary

This PR adds optional ETRecord generation support during ExecuTorch export, enabling easier debugging and analysis with the ExecuTorch Inspector.

### Changes

- Added a new opt-in `generate_etrecord` argument to `export_to_executorch`.
- When enabled, an ETRecord file (`{name}_etrecord.bin`) is generated alongside the exported `.pte` artifact.
- Propagated the flag through the XNNPACK export flow by wiring it into the `to_edge_transform_and_lower(...)` call, allowing ETRecord generation during lowering.
- Preserved existing behavior by keeping ETRecord generation **disabled by default**.
- Added warning logging when `generate_etrecord=True` is requested with unsupported recipes (`portable`, `coreml`, `cuda`, `cuda-windows`, `metal`) to avoid silent failures.

### Behavior

| Recipe | ETRecord Support |
|----------|----------------|
| `xnnpack` | ✅ Supported |
| `portable` | ⚠️ Warning logged |
| `coreml` | ⚠️ Warning logged |
| `cuda` | ⚠️ Warning logged |
| `cuda-windows` | ⚠️ Warning logged |
| `metal` | ⚠️ Warning logged |

### Impact

- No changes to existing export workflows unless `generate_etrecord=True` is explicitly specified.
- Provides ETRecord artifacts required for ExecuTorch Inspector debugging and profiling workflows.
- Improves user visibility for unsupported backend configurations through explicit warnings.