### PR TITLE
fix: address stable model export failures

### DIFF
--- a/optimum/executorch/attentions/custom_sdpa.py
+++ b/optimum/executorch/attentions/custom_sdpa.py
@@ -100,13 +100,13 @@ def custom_sdpa_with_start_pos_forward(
     else:
         attn_mask = None
         if is_causal:
-            # Calculate the input pos from attention mask.
-            # Branch out for float vs bool mask
-            # assert attention_mask.dim() == 2, f"attention_mask must be a 2D matrix."
-            assert (
-                position_ids is not None
-            ), "position_ids must be provided to find start position for causal attention"
-            start_pos = position_ids[0][0].item()
+            cache_position = kwargs.get("cache_position")
+            if position_ids is not None:
+                start_pos = position_ids[0][0].item()
+            elif cache_position is not None:
+                start_pos = cache_position[0].item()
+            else:
+                start_pos = 0
         else:
             start_pos = 0
 

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict
+from typing import Any, Dict, Optional
 
 import torch
 from packaging.version import parse
@@ -28,6 +28,7 @@ from transformers import (
     T5ForConditionalGeneration,
     WhisperForConditionalGeneration,
 )
+from transformers.cache_utils import StaticLayer
 from transformers.integrations.executorch import (
     TorchExportableModuleForDecoderOnlyLM,
 )
@@ -38,6 +39,43 @@ from optimum.executorch.attentions.custom_sdpa import get_custom_sdpa_for_ring_k
 from optimum.executorch.attentions.whisper_attention import WhisperCrossAttention
 
 from .utils import apply_chat_template_with_fallback, save_config_to_constant_methods
+
+
+class _AlwaysFalseDict(dict):
+    @classmethod
+    def fromkeys(cls, sequence, value=False):
+        return cls()
+
+    def get(self, key, default=None):
+        return False
+
+    def __setitem__(self, key, value):
+        return None
+
+
+class _Seq2SeqCrossAttentionStaticLayer(StaticLayer):
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        cache_kwargs: Optional[dict[str, Any]] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not self.is_initialized:
+            self.lazy_initialization(key_states)
+
+        cache_position = cache_kwargs.get("cache_position") if cache_kwargs is not None else None
+        cache_position = (
+            cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
+        )
+
+        try:
+            self.keys.index_copy_(2, cache_position, key_states)
+            self.values.index_copy_(2, cache_position, value_states)
+        except NotImplementedError:
+            self.keys[:, :, cache_position] = key_states
+            self.values[:, :, cache_position] = value_states
+
+        return key_states, value_states
 
 
 class VisionExportableModule(torch.nn.Module):
@@ -705,10 +743,10 @@ class MaskedLMExportableModule(torch.nn.Module):
             else attention_mask
         )
 
-        # Define dynamic shapes with Dim objects, always use Auto
+        seq_len_dim = torch.export.Dim("seq_length_dim", max=max_seq_length)
         dynamic_shapes = {
-            "input_ids": {1: torch.export.Dim.AUTO},
-            "attention_mask": {1: torch.export.Dim.AUTO},
+            "input_ids": {1: seq_len_dim},
+            "attention_mask": {1: seq_len_dim},
         }
 
         # Export the model with dynamic dimensions
@@ -789,6 +827,11 @@ class Seq2SeqLMDecoderExportableModuleWithStaticCache(torch.nn.Module):
             device=model.device,
             dtype=model.dtype,
         )
+        if isinstance(model, T5ForConditionalGeneration):
+            self.cross_attention_cache.layers = [
+                _Seq2SeqCrossAttentionStaticLayer(layer.max_cache_len)
+                for layer in self.cross_attention_cache.layers
+            ]
         self.cross_attention_cache.early_initialization(
             batch_size, cross_attention_heads, cross_head_dim, model.dtype, model.device
         )
@@ -817,6 +860,8 @@ class Seq2SeqLMDecoderExportableModuleWithStaticCache(torch.nn.Module):
         # self.cross_attention_cache._initialized = self.cross_attention_cache_initialized
 
         self.cache = EncoderDecoderCache(self.self_attention_cache, self.cross_attention_cache)
+        if isinstance(model, T5ForConditionalGeneration):
+            self.cache.is_updated = _AlwaysFalseDict.fromkeys(range(len(self.cross_attention_cache)), False)
         # Use custom cross attention for Whisper.
         # Only use WhisperCrossAttention if torch.ops.executorch.alias is available and device is CUDA.
         _has_et_alias = hasattr(torch.ops, "executorch") and hasattr(torch.ops.executorch, "alias")

--- a/optimum/exporters/executorch/integrations.py
+++ b/optimum/exporters/executorch/integrations.py
@@ -829,8 +829,7 @@ class Seq2SeqLMDecoderExportableModuleWithStaticCache(torch.nn.Module):
         )
         if isinstance(model, T5ForConditionalGeneration):
             self.cross_attention_cache.layers = [
-                _Seq2SeqCrossAttentionStaticLayer(layer.max_cache_len)
-                for layer in self.cross_attention_cache.layers
+                _Seq2SeqCrossAttentionStaticLayer(layer.max_cache_len) for layer in self.cross_attention_cache.layers
             ]
         self.cross_attention_cache.early_initialization(
             batch_size, cross_attention_heads, cross_head_dim, model.dtype, model.device

--- a/tests/models/test_modeling_gpt2.py
+++ b/tests/models/test_modeling_gpt2.py
@@ -43,9 +43,9 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
         parse(torchao.__version__) < parse("0.11.0"),
         reason="Quantization is only available on torchao >= 0.11.0.",
     )
-    def test_gpt2sw3_text_generation_with_custom_sdpa_and_kv_cache_8da4w_8we(self):
-        model_id = "AI-Sweden-Models/gpt-sw3-126m"
-        prompt = "Träd är fina för att"
+    def test_gpt2_text_generation_with_custom_sdpa_and_kv_cache_8da4w_8we(self):
+        model_id = "openai-community/gpt2"
+        prompt = "The weather is nice because"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         model = ExecuTorchModelForCausalLM.from_pretrained(
             model_id,

--- a/tests/models/test_modeling_t5.py
+++ b/tests/models/test_modeling_t5.py
@@ -20,8 +20,6 @@ import tempfile
 import unittest
 
 import pytest
-from executorch import version
-from packaging.version import parse
 from transformers import AutoTokenizer
 from transformers.testing_utils import slow
 
@@ -68,10 +66,6 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.portable
-    @pytest.mark.skipif(
-        parse(version.__version__) < parse("0.7.0"),
-        reason="Fixed on executorch >= 0.7.0",
-    )
     def test_t5_translation_portable(self):
         self._helper_t5_translation(recipe="portable")
 
@@ -122,9 +116,5 @@ class ExecuTorchModelIntegrationTest(unittest.TestCase):
     @slow
     @pytest.mark.run_slow
     @pytest.mark.portable
-    @pytest.mark.skipif(
-        parse(version.__version__) < parse("0.7.0"),
-        reason="Fixed on executorch >= 0.7.0",
-    )
     def test_t5_summarization_portable(self):
         self._helper_t5_summarization(recipe="portable")


### PR DESCRIPTION
Summary:

- Bound XLM-Roberta masked-LM dynamic sequence shapes to avoid ExecuTorch int_oo upper-bound failures.

- Switch GPT-2 coverage to public openai-community/gpt2 and handle missing position_ids via cache_position.

- Fix T5 dynamic encoder-length export by returning actual cross-attention K/V lengths instead of full static cross-cache buffers.

Test plan:

- GPT-2 focused slow test passes.

- XLM-Roberta direct main_export(..., "xnnpack") passes.

- T5 translation/summarization pass for both xnnpack and portable.
