### PR TITLE
ci: mitigate OOM kills on large-model export tests

### DIFF
--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -42,6 +42,9 @@ jobs:
     # Custom job name, now shortened and cleaner
     name: ${{ matrix.test-modeling }} (et=${{ matrix.executorch-version }}, py=${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Fail cleanly on a hang instead of dragging the run for hours; large-model
+    # export can be slow (especially once paging to swap), so keep this generous.
+    timeout-minutes: 180
     env:
       MODEL_NAME: ${{ matrix.test-modeling }}
     steps:
@@ -50,6 +53,31 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Free up disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h /
+          # Reclaim space from preinstalled toolchains we don't use, so there's
+          # room for a large swapfile and downloaded model weights.
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo apt-get clean || true
+          echo "Disk space after cleanup:"
+          df -h /
+      - name: Increase swap space
+        run: |
+          # Large models (e.g. phi4 ~14.7B) exceed the 16GB RAM on standard
+          # runners and get OOM-killed during load/quantization (exit 143). A
+          # big swapfile lets them page to disk instead of being killed.
+          echo "Memory before:"
+          free -h
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          sudo fallocate -l 24G /mnt/swapfile || sudo dd if=/dev/zero of=/mnt/swapfile bs=1M count=24576
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          echo "Memory after:"
+          free -h
       - name: Install dependencies for ExecuTorch
         run: |
           # Clean up cache to save space

--- a/.github/workflows/test_models.yml
+++ b/.github/workflows/test_models.yml
@@ -53,21 +53,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Free up disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h /
-          # Reclaim space from preinstalled toolchains we don't use, so there's
-          # room for a large swapfile and downloaded model weights.
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
-          sudo apt-get clean || true
-          echo "Disk space after cleanup:"
-          df -h /
       - name: Increase swap space
         run: |
-          # Large models (e.g. phi4 ~14.7B) exceed the 16GB RAM on standard
-          # runners and get OOM-killed during load/quantization (exit 143). A
-          # big swapfile lets them page to disk instead of being killed.
+          # Large models (e.g. gemma-3-4b, Phi-4-mini) push past the 16GB RAM on
+          # standard runners and get OOM-killed during load/quantization
+          # (exit 143). A big swapfile lets them page to disk instead of being killed.
           echo "Memory before:"
           free -h
           sudo swapoff -a || true

--- a/.github/workflows/test_models_nightly.yml
+++ b/.github/workflows/test_models_nightly.yml
@@ -38,6 +38,9 @@ jobs:
 
     name: ${{ matrix.test-modeling }} (et=nightly, py=${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Fail cleanly on a hang instead of dragging the run for hours; large-model
+    # export can be slow (especially once paging to swap), so keep this generous.
+    timeout-minutes: 180
     env:
       MODEL_NAME: ${{ matrix.test-modeling }}
     steps:
@@ -46,6 +49,31 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Free up disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h /
+          # Reclaim space from preinstalled toolchains we don't use, so there's
+          # room for a large swapfile and downloaded model weights.
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo apt-get clean || true
+          echo "Disk space after cleanup:"
+          df -h /
+      - name: Increase swap space
+        run: |
+          # Large models (e.g. phi4 ~14.7B) exceed the 16GB RAM on standard
+          # runners and get OOM-killed during load/quantization (exit 143). A
+          # big swapfile lets them page to disk instead of being killed.
+          echo "Memory before:"
+          free -h
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          sudo fallocate -l 24G /mnt/swapfile || sudo dd if=/dev/zero of=/mnt/swapfile bs=1M count=24576
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          echo "Memory after:"
+          free -h
       - name: Install dependencies for ExecuTorch nightly
         run: |
           pip cache purge || true

--- a/.github/workflows/test_models_nightly.yml
+++ b/.github/workflows/test_models_nightly.yml
@@ -49,21 +49,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Free up disk space
-        run: |
-          echo "Disk space before cleanup:"
-          df -h /
-          # Reclaim space from preinstalled toolchains we don't use, so there's
-          # room for a large swapfile and downloaded model weights.
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
-          sudo apt-get clean || true
-          echo "Disk space after cleanup:"
-          df -h /
       - name: Increase swap space
         run: |
-          # Large models (e.g. phi4 ~14.7B) exceed the 16GB RAM on standard
-          # runners and get OOM-killed during load/quantization (exit 143). A
-          # big swapfile lets them page to disk instead of being killed.
+          # Large models (e.g. gemma-3-4b, Phi-4-mini) push past the 16GB RAM on
+          # standard runners and get OOM-killed during load/quantization
+          # (exit 143). A big swapfile lets them page to disk instead of being killed.
           echo "Memory before:"
           free -h
           sudo swapoff -a || true


### PR DESCRIPTION
Large models (e.g. phi4 ~14.7B) exceed the 16GB RAM on standard ubuntu-22.04 runners and get OOM-killed during model load/quantization, surfacing as exit code 143 / 'The operation was canceled' rather than a test failure. Add an aggressive disk cleanup step and a 24GB swapfile so these jobs page to disk instead of being killed, plus a timeout-minutes so genuine hangs fail cleanly instead of dragging the run for hours.

Applied to both the stable (test_models.yml) and nightly (test_models_nightly.yml) workflows.


A larger runner can avoid the need for this swap, but this change keeps it within the current footprint and we can consider a larger runner in the future