### PR TITLE
Take argmax only over the last position

### DIFF
--- a/optimum/executorch/modeling.py
+++ b/optimum/executorch/modeling.py
@@ -750,7 +750,8 @@ class ExecuTorchModelForCausalLM(ExecuTorchModelBase):
                 cache_position=torch.arange(len(prompt_tokens), dtype=torch.long, device=self.device),
             )
             self.stats.on_sampling_end()
-            next_token = torch.argmax(logits, dim=-1)[0, -1].item()
+            # Slice first: prefill returns logits for every position, we need one.
+            next_token = torch.argmax(logits[:, -1, :], dim=-1).item()
         else:
             # Sequential prefill is preserved for backwards compatibility in order to run PTE generated w/o dynamic shapes.
             # TODO: We can remove this block once the executorch runtime supports `cache_position`.


### PR DESCRIPTION
Parallel prefill returns logits for the whole prompt, and the sampling step argmaxed that entire tensor before indexing the last row:

```
next_token = torch.argmax(logits, dim=-1)[0, -1].item()
```

This means there is a bunch of unnecessary results.

Instead, slice *first* then argmax on that.

Only the parallel prefill path is affected. The sequential prefill fallback and the decode loop call argmax on single position logits, where the two forms are equivalent, and the other call sites in this file already slice.